### PR TITLE
Various small improvements and fixes

### DIFF
--- a/docker/Dockerfile.jazzy-base
+++ b/docker/Dockerfile.jazzy-base
@@ -24,10 +24,6 @@ RUN /tmp/install_clangformat.sh && rm -f /tmp/install_clangformat.sh
 COPY docker/scripts/install_capnp.sh /tmp
 RUN /tmp/install_capnp.sh && rm -f /tmp/install_capnp.sh
 
-# Download, build and install PROJ
-COPY docker/scripts/install_proj.sh /tmp
-RUN /tmp/install_proj.sh && rm -f /tmp/install_proj.sh
-
 # Download, build and install Doxygen
 COPY docker/scripts/install_doxygen.sh /tmp
 RUN /tmp/install_doxygen.sh && rm -f /tmp/install_doxygen.sh
@@ -44,10 +40,6 @@ Pin: origin *
 Pin-Priority: -1
 
 Package: capnproto libcapnp-* libcapnp-dev
-Pin: origin *
-Pin-Priority: -1
-
-Package: proj proj-ps-doc proj-data proj-rdnap proj-bin libproj15 libproj-dev
 Pin: origin *
 Pin-Priority: -1
 EOF

--- a/docker/scripts/install_aptbase.sh
+++ b/docker/scripts/install_aptbase.sh
@@ -21,11 +21,15 @@ packages=$(awk -v filt=${FPSDK_IMAGE%-*} '$1 ~ filt { print $2 }' <<EOF
     noetic.humble.jazzy.bookworm    libeigen3-dev
     ..............jazzy.bookworm    libgtest-dev
     noetic.humble.jazzy.bookworm    libpath-tiny-perl
+    ..............jazzy.........    libproj25
+    ..............jazzy.........    libproj-dev
     noetic.humble.jazzy.bookworm    libsqlite3-dev
     noetic.humble.jazzy.bookworm    libtiff-dev
     noetic.humble.jazzy.bookworm    libyaml-cpp-dev
     noetic.humble.jazzy.bookworm    netbase
     .......humble.jazzy.bookworm    pre-commit
+    ..............jazzy.........    proj-data
+    ..............jazzy.........    proj-bin
     noetic......................    python3-catkin-tools
     noetic.humble.jazzy.bookworm    python-is-python3
     noetic.humble.jazzy.bookworm    python3-osrf-pycommon

--- a/fpsdk_common/CMakeLists.txt
+++ b/fpsdk_common/CMakeLists.txt
@@ -44,10 +44,10 @@ find_package (Threads REQUIRED)
 
 # PROJ is optional, unless explicitly requested with -DUSE_PROJ=ON
 if (USE_PROJ STREQUAL "ON")
-    find_package(PROJ 9.4.1 REQUIRED CONFIG)
+    find_package(PROJ 9.4 REQUIRED CONFIG)
 elseif(USE_PROJ STREQUAL "OFF")
 else()
-    find_package(PROJ 9.4.1 CONFIG QUIET)
+    find_package(PROJ 9.4 CONFIG QUIET)
 endif()
 if (${PROJ_FOUND})
     message(STATUS "fpsdk: Using PROJ (${PROJ_VERSION})")
@@ -193,6 +193,5 @@ add_gtest(TARGET thread_test          SOURCES test/thread_test.cpp          LINK
 add_gtest(TARGET trafo_test           SOURCES test/trafo_test.cpp           LINK_LIBS ${PROJECT_NAME})
 add_gtest(TARGET utils_test           SOURCES test/utils_test.cpp           LINK_LIBS ${PROJECT_NAME})
 add_gtest(TARGET yaml_test            SOURCES test/yaml_test.cpp            LINK_LIBS ${PROJECT_NAME})
-
 
 # ======================================================================================================================

--- a/fpsdk_common/include/fpsdk_common/parser/fpa.hpp
+++ b/fpsdk_common/include/fpsdk_common/parser/fpa.hpp
@@ -158,7 +158,7 @@ bool FpaGetMessageInfo(char* info, const std::size_t size, const uint8_t* msg, c
  */
 enum class FpaInitStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NOT_INIT                 = '0',  //!< Not initialised
     LOCAL_INIT               = '1',  //!< Locally initialised
     GLOBAL_INIT              = '2',  //!< Globally initialised
@@ -169,7 +169,7 @@ enum class FpaInitStatus : int
  */
 enum class FpaFusionStatusLegacy : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NONE                     = '0',  //!< Not started
     VISION                   = '1',  //!< Vision only
     VIO                      = '2',  //!< Visual-inertial fusion
@@ -182,7 +182,7 @@ enum class FpaFusionStatusLegacy : int
  */
 enum class FpaMeasStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NOT_USED                 = '0',  //!< Not used
     USED                     = '1',  //!< Used
     DEGRADED                 = '2',  //!< Degraded
@@ -193,7 +193,7 @@ enum class FpaMeasStatus : int
  */
 enum class FpaImuStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NOT_CONVERGED            = '0',  //!< Not converged
     WARMSTARTED              = '1',  //!< Warmstarted
     ROUGH_CONVERGED          = '2',  //!< Rough convergence
@@ -205,7 +205,7 @@ enum class FpaImuStatus : int
  */
 enum class FpaImuStatusLegacy : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NOT_CONVERGED            = '0',  //!< Not converged
     CONVERGED                = '1',  //!< Converged
 };  // clang-format on
@@ -215,7 +215,7 @@ enum class FpaImuStatusLegacy : int
  */
 enum class FpaImuNoise : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     LOW_NOISE                = '1',  //!< Low noise
     MEDIUM_NOISE             = '2',  //!< Medium noise
     HIGH_NOISE               = '3',  //!< High noise
@@ -230,7 +230,7 @@ enum class FpaImuNoise : int
  */
 enum class FpaImuConv : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     RESERVED0                = '0',  //!< Reserved
     WAIT_IMU_MEAS            = '1',  //!< Awaiting IMU measurements
     WAIT_GLOBAL_MEAS         = '2',  //!< Insufficient global measurements
@@ -246,7 +246,7 @@ enum class FpaImuConv : int
  */
 enum class FpaGnssStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NO_FIX                   = '0',  //!< No fix
     SPP                      = '1',  //!< Single-point positioning (SPP)
     RTK_MB                   = '2',  //!< RTK moving baseline
@@ -264,7 +264,7 @@ enum class FpaGnssStatus : int
  */
 enum class FpaCorrStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     WAITING_FUSION           = '0',  //!< Waiting fusion
     NO_GNSS                  = '1',  //!< No GNSS available
     NO_CORR                  = '2',  //!< No corrections used
@@ -282,7 +282,7 @@ enum class FpaCorrStatus : int
  */
 enum class FpaBaselineStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     WAITING_FUSION           = '0',  //!< Waiting fusion
     NO_FIX                   = '1',  //!< Not available or no fix
     FAILING                  = '2',  //!< Failing
@@ -294,7 +294,7 @@ enum class FpaBaselineStatus : int
  */
 enum class FpaCamStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     CAM_UNAVL                = '0',  //!< Camera not available
     BAD_FEAT                 = '1',  //!< Camera available, but not usable  (e.g. too dark)
     RESERVED2                = '2',  //!< Reserved
@@ -308,7 +308,7 @@ enum class FpaCamStatus : int
  */
 enum class FpaWsStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NOT_ENABLED              = '0',  //!< No wheelspeed enabled
     MISS_MEAS                = '1',  //!< Missing wheelspeed measurements
     NONE_CONVERGED           = '2',  //!< At least one wheelspeed enabled, no wheelspeed converged
@@ -321,7 +321,7 @@ enum class FpaWsStatus : int
  */
 enum class FpaWsStatusLegacy : int
 {  // clang-format off
-    UNSPECIFIED              = '?', //!< Unspecified
+    UNSPECIFIED              = '!', //!< Unspecified
     NOT_ENABLED              = '-', //!< No wheelspeed enabled
     NONE_CONVERGED           = '0', //!< None converged
     ONE_OR_MORE_CONVERGED    = '1', //!< At least one converged
@@ -332,7 +332,7 @@ enum class FpaWsStatusLegacy : int
  */
 enum class FpaWsConv : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     WAIT_FUSION              = '0',  //!< Awaiting Fusion
     WAIT_WS_MEAS             = '1',  //!< Missing wheelspeed measurements
     WAIT_GLOBAL_MEAS         = '2',  //!< Insufficient global measurements
@@ -347,7 +347,7 @@ enum class FpaWsConv : int
  */
 enum class FpaMarkersStatus : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     NOT_ENABLED              = '0',  //!< No markers available
     NONE_CONVERGED           = '1',  //!< Markers available
     ONE_CONVERGED            = '2',  //!< Markers available and used
@@ -359,7 +359,7 @@ enum class FpaMarkersStatus : int
  */
 enum class FpaMarkersConv : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     WAIT_FUSION              = '0',  //!< Awaiting Fusion
     WAIT_MARKER_MEAS         = '1',  //!< Waiting marker measurements
     WAIT_GLOBAL_MEAS         = '2',  //!< Insufficient global measurements
@@ -372,7 +372,7 @@ enum class FpaMarkersConv : int
  */
 enum class FpaGnssFix : int
 {  // clang-format off
-    UNSPECIFIED              = '?',  //!< Unspecified
+    UNSPECIFIED              = '!',  //!< Unspecified
     UNKNOWN                  = '0',  //!< Unknown
     NOFIX                    = '1',  //!< No fix
     DRONLY                   = '2',  //!< Dead-reckoning only
@@ -402,8 +402,8 @@ enum class FpaEpoch : int
 enum class FpaAntState : int
 {
     UNSPECIFIED = 0,  //!< Unspecified
-    OK,               //!< Antenna detected and good
     OPEN,             //!< No antenna detected (or connected via DC block)
+    OK,               //!< Antenna detected and good
     SHORT,            //!< Antenna short circuit detected
 };
 
@@ -623,9 +623,9 @@ struct FpaImuPayload : public FpaPayload
     //! Data from which FP_A-...IMU is stored
     enum class Which
     {
-        UNSPECIFIED,   //!< Unspecified
-        FP_A_RAWIMU,   //!< Data is from FP_A-RAWIMU
-        FP_A_CORRIMU,  //!< Data is from FP_A-CORRIMU
+        UNSPECIFIED,  //!< Unspecified
+        RAWIMU,       //!< Data is from FP_A-RAWIMU
+        CORRIMU,      //!< Data is from FP_A-CORRIMU
     };
     Which which = Which::UNSPECIFIED;  //!< Indicates from which message the data is
     // clang-format off
@@ -728,27 +728,28 @@ struct FpaOdomPayload : public FpaPayload
     //! Data from which FP_A-...IMU is stored
     enum class Which
     {
-        UNSPECIFIED,    //!< Unspecified
-        FP_A_ODOMETRY,  //!< Data is from FP_A-ODOMETRY
-        FP_A_ODOMENU,   //!< Data is from FP_A-ODOMENU
-        FP_A_ODOMSH,    //!< Data is from FP_A-ODOMSH
+        UNSPECIFIED,  //!< Unspecified
+        ODOMETRY,     //!< Data is from FP_A-ODOMETRY
+        ODOMENU,      //!< Data is from FP_A-ODOMENU
+        ODOMSH,       //!< Data is from FP_A-ODOMSH
     };
     // clang-format off
-    Which which = Which::UNSPECIFIED;  //!< Indicates from which message the data is
-    FpaGpsTime             gps_time;           //!< Time
-    FpaFloat3              pos;                //!< Position, X/Y/Z components
-    FpaFloat4              orientation;        //!< Quaternion, W/X/Y/Z components
-    FpaFloat3              vel;                //!< Velocity, X/Y/Z components
-    FpaFloat3              rot;                //!< Bias corrected angular velocity, X/Y/Z components
-    FpaFloat3              acc;                //!< Bias corrected acceleration, X/Y/Z components
-    FpaFusionStatusLegacy  fusion_status;      //!< Fustion status
-    FpaImuStatusLegacy     imu_bias_status;    //!< IMU bias status
-    FpaGnssFix             gnss1_fix;          //!< Fix status of GNSS1 receiver
-    FpaGnssFix             gnss2_fix;          //!< Fix status of GNSS2 receiver
-    FpaWsStatusLegacy      wheelspeed_status;  //!< Wheelspeed status
-    FpaFloat6              pos_cov;            //!< Position covariance, XX/YY/ZZ/XY/YZ/XZ components
-    FpaFloat6              orientation_cov;    //!< Orientation covariance, XX/YY/ZZ/XY/YZ/XZ components
-    FpaFloat6              vel_cov;            //!< Velocity covariance, XX/YY/ZZ/XY/YZ/XZ components
+    Which which = Which::UNSPECIFIED;            //!< Indicates from which message the data is
+    FpaGpsTime             gps_time;             //!< Time
+    FpaFloat3              pos;                  //!< Position, X/Y/Z components
+    FpaFloat4              orientation;          //!< Quaternion, W/X/Y/Z components
+    FpaFloat3              vel;                  //!< Velocity, X/Y/Z components
+    FpaFloat3              rot;                  //!< Bias corrected angular velocity, X/Y/Z components
+    FpaFloat3              acc;                  //!< Bias corrected acceleration, X/Y/Z components
+    FpaFusionStatusLegacy  fusion_status;        //!< Fustion status
+    FpaImuStatusLegacy     imu_bias_status;      //!< IMU bias status
+    FpaGnssFix             gnss1_fix;            //!< Fix status of GNSS1 receiver
+    FpaGnssFix             gnss2_fix;            //!< Fix status of GNSS2 receiver
+    FpaWsStatusLegacy      wheelspeed_status;    //!< Wheelspeed status
+    FpaFloat6              pos_cov;              //!< Position covariance, XX/YY/ZZ/XY/YZ/XZ components
+    FpaFloat6              orientation_cov;      //!< Orientation covariance, XX/YY/ZZ/XY/YZ/XZ components
+    FpaFloat6              vel_cov;              //!< Velocity covariance, XX/YY/ZZ/XY/YZ/XZ components
+    char                   version[100] = { 0 };  //!< Version
     // clang-format on
 
     /**

--- a/fpsdk_common/include/fpsdk_common/parser/nmea.hpp
+++ b/fpsdk_common/include/fpsdk_common/parser/nmea.hpp
@@ -177,12 +177,10 @@ struct NmeaCoordinates
 
 /**
  * @brief NMEA talker IDs
- *
- * @note Do not use <, >, >=, <= operators on this!
  */
 enum class NmeaTalkerId : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     PROPRIETARY = 'x',  //!< Proprietary
     GPS_SBAS    = 'P',  //!< GPS and/or SBAS
     GLO         = 'L',  //!< GLONASS
@@ -195,12 +193,10 @@ enum class NmeaTalkerId : int
 
 /**
  * @brief NMEA-Gx-GGA quality indicator
- *
- * @note Do not use <, >, >=, <= operators on this!
  */
 enum class NmeaQualityGga : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     NOFIX       = '0',  //!< No fix
     SPP         = '1',  //!< Autonomous GNSS fix
     DGNSS       = '2',  //!< Differential GPS fix (e.g. with SBAS)
@@ -219,7 +215,7 @@ enum class NmeaQualityGga : int
  */
 enum class NmeaStatusGllRmc : int
 {  // clang-format off
-    UNSPECIFIED  = '?',  //!< Unspecified
+    UNSPECIFIED  = '!',  //!< Unspecified
     INVALID      = 'V',  //!< Data invalid
     VALID        = 'A',  //!< Data valid
  // DIFFERENTIAL = 'D',  // @todo another possible value?
@@ -232,7 +228,7 @@ enum class NmeaStatusGllRmc : int
  */
 enum class NmeaModeGllVtg : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     INVALID     = 'N',  //!< Invalid (no fix)
     AUTONOMOUS  = 'A',  //!< Autonomous mode (SPP)
     DGNSS       = 'D',  //!< Differential GNSS fix
@@ -248,7 +244,7 @@ enum class NmeaModeGllVtg : int
  */
 enum class NmeaModeRmcGns : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     INVALID     = 'N',  //!< Invalid (no fix)
     AUTONOMOUS  = 'A',  //!< Autonomous mode (SPP)
     DGNSS       = 'D',  //!< Differential GNSS fix
@@ -267,7 +263,7 @@ enum class NmeaModeRmcGns : int
  */
 enum class NmeaNavStatusRmc : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     SAFE        = 'S',  //!< Safe
     CAUTION     = 'C',  //!< Caution
     UNSAFE      = 'U',  //!< Unsafe
@@ -281,19 +277,17 @@ enum class NmeaNavStatusRmc : int
  */
 enum class NmeaOpModeGsa : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     MANUAL      = 'M',  //!< Manual
     AUTO        = 'A',  //!< Automatic
 };  // clang-format on
 
 /**
  * @brief NMEA-Gx-GNS nav mode
- *
- * @note Do not use <, >, >=, <= operators on this!
  */
 enum class NmeaNavModeGsa : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     NOFIX       = '1',  //!< No fix
     FIX2D       = '2',  //!< 2D fix
     FIX3D       = '3',  //!< 3D fix
@@ -301,10 +295,12 @@ enum class NmeaNavModeGsa : int
 
 /**
  * @brief NMEA system IDs
+ *
+ * @note Do not use <, >, >=, <= operators on this!
  */
 enum class NmeaSystemId : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     GPS_SBAS    = '1',  //!< GPS and/or SBAS
     GLO         = '2',  //!< GLONASS
     GAL         = '3',  //!< Galileo
@@ -315,10 +311,12 @@ enum class NmeaSystemId : int
 
 /**
  * @brief NMEA signal IDs
+ *
+ * @note Do not use <, >, >=, <= operators on this!
  */
 enum class NmeaSignalId : int
 {  // clang-format off
-    UNSPECIFIED = '?',  //!< Unspecified
+    UNSPECIFIED = '!',  //!< Unspecified
     GPS_L1CA    = '1',  //!< GPS L1 C/A
     GPS_L2CL    = '6',  //!< GPS L2 CL
     GPS_L2CM    = '5',  //!< GPS L2 CM

--- a/fpsdk_common/include/fpsdk_common/parser/novb.hpp
+++ b/fpsdk_common/include/fpsdk_common/parser/novb.hpp
@@ -26,6 +26,7 @@
 #define __FPSDK_COMMON_PARSER_NOVB_HPP__
 
 /* LIBC/STL */
+#include <cstddef>
 #include <cstdint>
 
 /* EXTERNAL */
@@ -227,6 +228,34 @@ struct NovbShortHeader
 };  // clang-format on
 
 static_assert(sizeof(NovbShortHeader) == NOV_B_HEAD_SIZE_SHORT, "");
+
+enum class NovbMsgTypeSource : uint8_t;  // forward declaration
+
+/**
+ * @brief Union of NOV_B long and short header
+ */
+struct NovbHeader
+{
+    union
+    {
+        NovbLongHeader long_header;    //!< Long header
+        NovbShortHeader short_header;  //!< Short header
+    };
+    /**
+     * @brief Check for long vs short header
+     *
+     * @returns true if long_header is valid, false if short_header is valid
+     */
+    bool IsLongHeader() const;
+    /**
+     * @brief Get message type source
+     *
+     * @returns the message type source (NovbMsgTypeSource::_MASK if unknown)
+     */
+    NovbMsgTypeSource Source() const;
+};
+
+static_assert(sizeof(NovbHeader) == sizeof(NovbLongHeader), "");
 
 /**
  * @brief Message type measurement source (bits 4..0 of NovbLongHeader.message_type)

--- a/fpsdk_common/include/fpsdk_common/time.hpp
+++ b/fpsdk_common/include/fpsdk_common/time.hpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <cstdint>
 #include <ctime>
+#include <string>
 
 /* EXTERNAL */
 

--- a/fpsdk_common/src/parser/fpa.cpp
+++ b/fpsdk_common/src/parser/fpa.cpp
@@ -899,7 +899,7 @@ bool FpaRawimuPayload::SetFromMsg(const uint8_t* msg, const std::size_t msg_size
               GetFloatArr(rot, m.fields_, 5, false));
     }
     if (ok) {
-        which = Which::FP_A_RAWIMU;
+        which = Which::RAWIMU;
     }
     FPA_TRACE("FpaRawimuPayload %s", ok ? "true" : "false");
     return ok;
@@ -918,7 +918,7 @@ bool FpaCorrimuPayload::SetFromMsg(const uint8_t* msg, const std::size_t msg_siz
               GetFloatArr(rot, m.fields_, 5, false));
     }
     if (ok) {
-        which = Which::FP_A_CORRIMU;
+        which = Which::CORRIMU;
     }
     FPA_TRACE("FpaCorrimuPayload %s", ok ? "true" : "false");
     return ok;
@@ -977,10 +977,10 @@ bool FpaOdometryPayload::SetFromMsg(const uint8_t* msg, const std::size_t msg_si
               GetImuStatusLegacy(imu_bias_status, m.fields_[19]) && GetGnssFix(gnss1_fix, m.fields_[20]) &&
               GetGnssFix(gnss2_fix, m.fields_[21]) && GetWsStatusLegacy(wheelspeed_status, m.fields_[22]) &&
               GetFloatArr(pos_cov, m.fields_, 23, false) && GetFloatArr(orientation_cov, m.fields_, 29, false) &&
-              GetFloatArr(vel_cov, m.fields_, 35, false));
+              GetFloatArr(vel_cov, m.fields_, 35, false) && GetText(version, sizeof(version), m.fields_[41]));
     }
     if (ok) {
-        which = Which::FP_A_ODOMETRY;
+        which = Which::ODOMETRY;
     }
     FPA_TRACE("FpaOdometryPayload %s", ok ? "true" : "false");
     return ok;
@@ -1003,7 +1003,7 @@ bool FpaOdomenuPayload::SetFromMsg(const uint8_t* msg, const std::size_t msg_siz
               GetFloatArr(vel_cov, m.fields_, 35, false));
     }
     if (ok) {
-        which = Which::FP_A_ODOMENU;
+        which = Which::ODOMENU;
     }
     FPA_TRACE("FpaOdomenuPayload %s", ok ? "true" : "false");
     return ok;
@@ -1026,7 +1026,7 @@ bool FpaOdomshPayload::SetFromMsg(const uint8_t* msg, const std::size_t msg_size
               GetFloatArr(vel_cov, m.fields_, 35, false));
     }
     if (ok) {
-        which = Which::FP_A_ODOMSH;
+        which = Which::ODOMSH;
     }
     FPA_TRACE("FpaOdomshPayload %s", ok ? "true" : "false");
     return ok;

--- a/fpsdk_common/src/parser/novb.cpp
+++ b/fpsdk_common/src/parser/novb.cpp
@@ -26,6 +26,7 @@
 
 /* PACKAGE */
 #include "fpsdk_common/parser/novb.hpp"
+#include "fpsdk_common/types.hpp"
 
 namespace fpsdk {
 namespace common {
@@ -90,6 +91,24 @@ bool NovbGetMessageName(char* name, const std::size_t size, const uint8_t* msg, 
 
     // If that failed, too, stringify the message ID
     return std::snprintf(name, size, "NOV_B-MSG%05" PRIu16, msg_id) < (int)size;
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+bool NovbHeader::IsLongHeader() const
+{
+    return long_header.sync3 == NOV_B_SYNC_3_LONG;
+}
+
+NovbMsgTypeSource NovbHeader::Source() const
+{
+    if (long_header.sync3 == NOV_B_SYNC_3_LONG) {
+        return static_cast<NovbMsgTypeSource>(
+            long_header.message_type & fpsdk::common::types::EnumToVal(NovbMsgTypeSource::_MASK));
+
+    } else {
+        return NovbMsgTypeSource::_MASK;
+    }
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/fpsdk_common/test/parser_fpa_test.cpp
+++ b/fpsdk_common/test/parser_fpa_test.cpp
@@ -344,7 +344,7 @@ TEST(FpaTest, FpaRawimuPayload)
         const char* msg =  // clang-format off
             "$FP,RAWIMU,1,2197,126191.777855,-0.199914,0.472851,9.917973,0.023436,0.007723,0.002131*34\r\n";  // clang-format on
         EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
-        EXPECT_EQ(payload.which, FpaImuPayload::Which::FP_A_RAWIMU);
+        EXPECT_EQ(payload.which, FpaImuPayload::Which::RAWIMU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2197);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -363,7 +363,7 @@ TEST(FpaTest, FpaRawimuPayload)
         const char* msg =  // clang-format off
             "$FP,RAWIMU,1,,,,,,,,*XX\r\n";  // clang-format on
         EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
-        EXPECT_EQ(payload.which, FpaImuPayload::Which::FP_A_RAWIMU);
+        EXPECT_EQ(payload.which, FpaImuPayload::Which::RAWIMU);
         EXPECT_FALSE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 0);
         EXPECT_FALSE(payload.gps_time.tow.valid);
@@ -388,7 +388,7 @@ TEST(FpaTest, FpaCorrimuPayload)
         const char* msg =  // clang-format off
             "$FP,CORRIMU,1,2197,126191.777855,-0.195224,0.393969,9.869998,0.013342,-0.004620,-0.000728*7D\r\n";  // clang-format on
         EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
-        EXPECT_EQ(payload.which, FpaImuPayload::Which::FP_A_CORRIMU);
+        EXPECT_EQ(payload.which, FpaImuPayload::Which::CORRIMU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2197);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -407,7 +407,7 @@ TEST(FpaTest, FpaCorrimuPayload)
         const char* msg =  // clang-format off
             "$FP,CORRIMU,1,,,,,,,,*XX\r\n";  // clang-format on
         EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
-        EXPECT_EQ(payload.which, FpaImuPayload::Which::FP_A_CORRIMU);
+        EXPECT_EQ(payload.which, FpaImuPayload::Which::CORRIMU);
         EXPECT_FALSE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 0);
         EXPECT_FALSE(payload.gps_time.tow.valid);
@@ -547,7 +547,7 @@ TEST(FpaTest, FpaOdometryPayload)
             "0.01761,0.02274,0.01713,-0.00818,0.00235,0.00129,0.00013,0.00015,0.00014,-0.00001,0.00001,0.00002,"
             "0.03482,0.06244,0.05480,0.00096,0.00509,0.00054,fp_release_vr2_2.54.0_160*4F\r\n";  // clang-format on
         EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
-        EXPECT_EQ(payload.which, FpaOdomPayload::Which::FP_A_ODOMETRY);
+        EXPECT_EQ(payload.which, FpaOdomPayload::Which::ODOMETRY);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2231);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -599,6 +599,7 @@ TEST(FpaTest, FpaOdometryPayload)
         EXPECT_NEAR(payload.vel_cov.values[3], 0.00096, 1e-9);
         EXPECT_NEAR(payload.vel_cov.values[4], 0.00509, 1e-9);
         EXPECT_NEAR(payload.vel_cov.values[5], 0.00054, 1e-9);
+        EXPECT_EQ(std::string(payload.version), "fp_release_vr2_2.54.0_160");
     }
 }
 
@@ -614,11 +615,12 @@ TEST(FpaTest, FpaOdomenuPayload)
             "-0.00149,-0.00084,0.00025,0.00003,0.00003,0.00012,0.00000,0.00000,0.00000,0.01742,0.01146,0.01612,"
             "-0.00550,-0.00007,-0.00050*74\r\n";  // clang-format on
         EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
-        EXPECT_EQ(payload.which, FpaOdomPayload::Which::FP_A_ODOMENU);
+        EXPECT_EQ(payload.which, FpaOdomPayload::Which::ODOMENU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2180);
         EXPECT_TRUE(payload.gps_time.tow.valid);
         EXPECT_NEAR(payload.gps_time.tow.value, 298591.500000, 1e-9);
+        EXPECT_TRUE(std::string(payload.version).empty());
     }
 }
 
@@ -634,11 +636,12 @@ TEST(FpaTest, FpaOdomshPayload)
             "-0.00149,-0.00084,0.00025,0.00003,0.00003,0.00012,0.00000,0.00000,0.00000,0.01742,0.01146,0.01612,"
             "-0.00550,-0.00007,-0.00050*74\r\n";  // clang-format on
         EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
-        EXPECT_EQ(payload.which, FpaOdomPayload::Which::FP_A_ODOMSH);
+        EXPECT_EQ(payload.which, FpaOdomPayload::Which::ODOMSH);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2180);
         EXPECT_TRUE(payload.gps_time.tow.valid);
         EXPECT_NEAR(payload.gps_time.tow.value, 298591.500000, 1e-9);
+        EXPECT_TRUE(std::string(payload.version).empty());
     }
 }
 

--- a/fpsdk_doc/README.md
+++ b/fpsdk_doc/README.md
@@ -24,7 +24,7 @@ For building the libraries and apps:
 - Eigen3          (≥ 3.3.7,  tested with 3.3.7, 3.4.0)
 - yaml-cpp        (≥ 0.6.2,  tested with 0.6.2, 0.7.0, 0.8.0)
 - zlib1g          (≥ 1.2.11, tested with 1.2.11, 1.2.13, 1.3)
-- PROJ        (*) (≥ 9.?.?,  tested with 9.4.1)
+- PROJ        (*) (≥ 9.4.x,  tested with 9.4.0, 9.4.1)
 - ROS1        (*) (Noetic), or
 - ROS2        (*) (Humble or Jazzy)
 

--- a/fpsdk_ros1/include/fpsdk_ros1/utils.hpp
+++ b/fpsdk_ros1/include/fpsdk_ros1/utils.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 /* EXTERNAL */
+#include <fpsdk_ros1/ext/ros_console.hpp>
 #include <fpsdk_ros1/ext/ros_time.hpp>
 
 /* Fixposition SDK */
@@ -52,8 +53,12 @@ namespace utils {
  * - WARNING         --> WARN
  * - ERROR           --> ERROR
  * - FATAL           --> FATAL
+ *
+ * @param[in]  logger_name  The name of the logger. The default value should give the caller package's
+ *                          ROSCONSOLE_DEFAULT_NAME, for example, "ros1_fpsdk_demo". That is, typically this argument
+ *                          should be left empty (the default value).
  */
-void RedirectLoggingToRosConsole();
+void RedirectLoggingToRosConsole(const char* logger_name = ROSCONSOLE_DEFAULT_NAME /* = caller's package name */);
 
 /**
  * @brief Loads a parameter from the ROS parameter server (int)

--- a/fpsdk_ros1/src/utils.cpp
+++ b/fpsdk_ros1/src/utils.cpp
@@ -12,6 +12,7 @@
  */
 
 /* LIBC/STL */
+#include <cstring>
 
 /* EXTERNAL */
 #include "fpsdk_ros1/ext/ros.hpp"
@@ -31,26 +32,31 @@ using namespace fpsdk::common::logging;
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+static char g_logger_name[100];
+
 static void sLoggingFn(const LoggingParams& /*params*/, const LoggingLevel level, const char* str)
 {
-    // These will appear under the "ros.fpsdk_ros1" logger.
-    // @todo Can we make this log to "ros1.fpsdk_common"?
     switch (level) {  // clang-format off
-        case LoggingLevel::TRACE:   ROS_DEBUG("%s", str); break;
-        case LoggingLevel::DEBUG:   ROS_DEBUG("%s", str); break;
-        case LoggingLevel::INFO:    ROS_INFO( "%s", str); break;
-        case LoggingLevel::NOTICE:  ROS_INFO( "%s", str); break;
-        case LoggingLevel::WARNING: ROS_WARN( "%s", str); break;
-        case LoggingLevel::ERROR:   ROS_ERROR("%s", str); break;
-        case LoggingLevel::FATAL:   ROS_FATAL("%s", str); break;
+        case LoggingLevel::TRACE:   ROS_LOG(ros::console::levels::Debug, g_logger_name, "%s", str); break;
+        case LoggingLevel::DEBUG:   ROS_LOG(ros::console::levels::Debug, g_logger_name, "%s", str); break;
+        case LoggingLevel::INFO:    ROS_LOG(ros::console::levels::Info,  g_logger_name, "%s", str); break;
+        case LoggingLevel::NOTICE:  ROS_LOG(ros::console::levels::Info,  g_logger_name, "%s", str); break;
+        case LoggingLevel::WARNING: ROS_LOG(ros::console::levels::Warn,  g_logger_name, "%s", str); break;
+        case LoggingLevel::ERROR:   ROS_LOG(ros::console::levels::Error, g_logger_name, "%s", str); break;
+        case LoggingLevel::FATAL:   ROS_LOG(ros::console::levels::Fatal, g_logger_name, "%s", str); break;
     }  // clang-format on
 }
 
-void RedirectLoggingToRosConsole()
+void RedirectLoggingToRosConsole(const char* logger_name)
 {
     LoggingParams params = LoggingGetParams();
     params.fn_ = sLoggingFn;
     params.level_ = LoggingLevel::TRACE;  // We leave it up to ROS to decide what to print
+    // Set logger name. Note that ROSCONSOLE_DEFAULT_NAME here is the "ros.fpsdk_ros1" package name. However, when
+    // called from the app (node) then the default argument to logger_name is that package's ROSCONSOLE_DEFAULT_NAME,
+    // e.g. "ros.ros1_fpsdk_demo"
+    std::snprintf(
+        g_logger_name, sizeof(g_logger_name), "%s", logger_name != NULL ? logger_name : ROSCONSOLE_DEFAULT_NAME);
     LoggingSetParams(params);
 }
 

--- a/fpsdk_ros2/include/fpsdk_ros2/utils.hpp
+++ b/fpsdk_ros2/include/fpsdk_ros2/utils.hpp
@@ -42,15 +42,17 @@ namespace utils {
  * This configures the fpsdk::common::logging facility to output via the ROS console. This does *not* configure the ROS
  * console (logger level, logger name, etc.).
  *
- * The mapping of fpsdk::common::logging::LoggingLevel to ros::console::levels is as follows:
+ * The mapping of fpsdk::common::logging::LoggingLevel to rclcpp levels is as follows:
  *
  * - TRACE and DEBUG --> DEBUG
  * - INFO and NOTICE --> INFO
  * - WARNING         --> WARN
  * - ERROR           --> ERROR
  * - FATAL           --> FATAL
+ *
+ * @param[in]  logger_name  The name of the logger. The recommended value is node->get_logger().get_name()
  */
-void RedirectLoggingToRosConsole();
+void RedirectLoggingToRosConsole(const char* logger_name = "fpsdk_ros2");
 
 /**
  * @brief Convert to ROS time (atomic -> POSIX)

--- a/fpsdk_ros2/src/utils.cpp
+++ b/fpsdk_ros2/src/utils.cpp
@@ -47,9 +47,9 @@ static void sLoggingFn(const LoggingParams& /*params*/, const LoggingLevel level
     }  // clang-format on
 }
 
-void RedirectLoggingToRosConsole()
+void RedirectLoggingToRosConsole(const char* logger_name)
 {
-    g_logger = std::make_unique<rclcpp::Logger>(rclcpp::get_logger("fpsdk_ros2"));
+    g_logger = std::make_unique<rclcpp::Logger>(rclcpp::get_logger(logger_name));
     LoggingParams params = LoggingGetParams();
     params.fn_ = sLoggingFn;
     params.level_ = LoggingLevel::TRACE;  // We leave it up to ROS to decide what to print

--- a/ros1_fpsdk_demo/launch/console.conf
+++ b/ros1_fpsdk_demo/launch/console.conf
@@ -1,3 +1,2 @@
 log4j.logger.ros=INFO
-log4j.logger.ros.fpsdk_ros1=DEBUG
 log4j.logger.ros.ros1_fpsdk_demo=DEBUG

--- a/ros1_fpsdk_demo/src/node_main.cpp
+++ b/ros1_fpsdk_demo/src/node_main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char** argv)
 {
 #ifndef NDEBUG
     fpsdk::common::app::StacktraceHelper stacktrace;
+    WARNING("***** Running debug build *****");
 #endif
     ROS_INFO("main() 0x%" PRIxMAX, fpsdk::common::thread::ThisThreadId());
 
@@ -44,10 +45,10 @@ int main(int argc, char** argv)
     ros::init(argc, argv, "ros1_fpsdk_demo_node");
     ros::NodeHandle nh("~");
 
-    // Redirect Fixposition SDK logging to ROS console
+    // Redirect Fixposition SDK logging to ROS console, all should use the "ros.ros1_fpsdk_demo" logger
     fpsdk::ros1::utils::RedirectLoggingToRosConsole();
-    DEBUG("This is a message from fpsdk_common's logging, redirected to the ROS console");  // logger: "ros1.fpsdk_ros1"
-    ROS_DEBUG("This is a proper ROS console message");  // logger: "ros.ros1_fpsdk_demo"
+    DEBUG("This is a message from fpsdk_common's logging, redirected to the ROS console");
+    ROS_DEBUG("This is a proper ROS console message");
 
     // Handle CTRL-C / SIGINT ourselves
     fpsdk::common::app::SigIntHelper sigint;

--- a/ros2_fpsdk_demo/include/ros2_fpsdk_demo/node.hpp
+++ b/ros2_fpsdk_demo/include/ros2_fpsdk_demo/node.hpp
@@ -14,9 +14,10 @@
 #define __ROS2_FPSDK_DEMO_NODE_HPP__
 
 /* LIBC/STL */
+#include <memory>
 
 /* EXTERNAL */
-#include <rclcpp/rclcpp.hpp>
+#include <fpsdk_ros2/ext/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
 
 /* Fixposition SDK */
@@ -31,7 +32,7 @@ class DemoParams
 {
    public:
     DemoParams();
-    bool LoadFromRos(std::shared_ptr<rclcpp::Node> node);
+    bool LoadFromRos(std::shared_ptr<rclcpp::Node> nh, const std::string& ns = "");
 
     double worker1_interval_;
     double worker2_interval_;
@@ -42,17 +43,18 @@ class DemoParams
     static constexpr double INTERVAL_MAX = 10.0;
 };
 
-class DemoNode : public rclcpp::Node
+class DemoNode
 {
    public:
-    DemoNode();
+    DemoNode(std::shared_ptr<rclcpp::Node> nh, const DemoParams& params);
     ~DemoNode();
-    bool LoadParams();
     bool Start();
     void Stop();
 
    private:
+    std::shared_ptr<rclcpp::Node> nh_;
     DemoParams params_;
+    rclcpp::Logger logger_;
     fpsdk::common::thread::Thread worker1_;
     fpsdk::common::thread::Thread worker2_;
     rclcpp::TimerBase::SharedPtr timer1_;

--- a/ros2_fpsdk_demo/launch/console.conf
+++ b/ros2_fpsdk_demo/launch/console.conf
@@ -1,3 +1,0 @@
-log4j.logger.ros=INFO
-log4j.logger.ros.fpsdk_ros1=DEBUG
-log4j.logger.ros.ros1_fpsdk_demo=DEBUG


### PR DESCRIPTION
- Use libproj from Ubuntu 24 instead of manually installing for fixposition-sdk-jazzy:* images
- Use better value for fpa/nmea UNSPECIFIED enum values (so that <> etc. works in more cases)
- Add NovbHeader union for short and long headers
- Allow redirecting logging to ROS1/ROS2 logger using the node's logger name, update demo nodes accordingly
- Update ros2_fpsdk_demo for a better scheme to create and run the node (use same nh/params pattern like in ros1_fpsdk_demo)
- Fix some includes
- Some cosmetics