### PR TITLE
separate docker build from run, expire old images automatically

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,11 +22,11 @@ jobs:
             - name: Build
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  COMPOSE_PARALLEL_LIMIT=1 docker compose build bookworm-base bookworm-ci bookworm-dev
+                  COMPOSE_PARALLEL_LIMIT=1 docker compose build build-bookworm-base build-bookworm-ci build-bookworm-dev
             - name: Push
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  docker compose push bookworm-base bookworm-ci bookworm-dev
+                  docker compose push build-bookworm-base build-bookworm-ci build-bookworm-dev
 
     docker-fpsdk-noetic:
         runs-on: ubuntu-latest
@@ -42,11 +42,11 @@ jobs:
             - name: Build
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  COMPOSE_PARALLEL_LIMIT=1 docker compose build noetic-base noetic-ci noetic-dev
+                  COMPOSE_PARALLEL_LIMIT=1 docker compose build build-noetic-base build-noetic-ci build-noetic-dev
             - name: Push
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  docker compose push noetic-base noetic-ci noetic-dev
+                  docker compose push build-noetic-base build-noetic-ci build-noetic-dev
 
     docker-fpsdk-humble:
         runs-on: ubuntu-latest
@@ -62,11 +62,11 @@ jobs:
             - name: Build
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  COMPOSE_PARALLEL_LIMIT=1 docker compose build humble-base humble-ci humble-dev
+                  COMPOSE_PARALLEL_LIMIT=1 docker compose build build-humble-base build-humble-ci build-humble-dev
             - name: Push
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  docker compose push humble-base humble-ci humble-dev
+                  docker compose push build-humble-base build-humble-ci build-humble-dev
 
     docker-fpsdk-jazzy:
         runs-on: ubuntu-latest
@@ -82,8 +82,24 @@ jobs:
             - name: Build
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  COMPOSE_PARALLEL_LIMIT=1 docker compose build jazzy-base jazzy-ci jazzy-dev
+                  COMPOSE_PARALLEL_LIMIT=1 docker compose build build-jazzy-base build-jazzy-ci build-jazzy-dev
             - name: Push
               run: |
                   cd ${GITHUB_WORKSPACE}/docker
-                  docker compose push jazzy-base jazzy-ci jazzy-dev
+                  docker compose push build-jazzy-base build-jazzy-ci build-jazzy-dev
+
+    docker-fpsdk-cleanup:
+        runs-on: ubuntu-latest
+        needs:
+            - docker-fpsdk-bookworm
+            - docker-fpsdk-noetic
+            - docker-fpsdk-humble
+            - docker-fpsdk-jazzy
+        steps:
+            - name: Expire old images
+              uses: actions/delete-package-versions@v5
+              with:
+                  package-name:                  ${{ github.event.repository.name }}
+                  package-type:                  container
+                  min-versions-to-keep:          0
+                  delete-only-untagged-versions: true

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,27 +4,34 @@ services:
 
     # ----- no ROS -----------------------------------------------------------------------------------------------------
 
-    bookworm-base:
+    build-bookworm-base:
         image: ghcr.io/fixposition/fixposition-sdk:bookworm-base
         build:
             context: ..
             dockerfile: docker/Dockerfile.bookworm-base
-        command: tail -f
-    bookworm-ci:
+    build-bookworm-ci:
         image: ghcr.io/fixposition/fixposition-sdk:bookworm-ci
         build:
             context: ..
             dockerfile: docker/Dockerfile.bookworm-ci
         depends_on:
-            - bookworm-base
-        command: tail -f
-    bookworm-dev:
+            - build-bookworm-base
+    build-bookworm-dev:
         image: ghcr.io/fixposition/fixposition-sdk:bookworm-dev
         build:
             context: ..
             dockerfile: docker/Dockerfile.bookworm-dev
         depends_on:
-            - bookworm-base
+            - build-bookworm-base
+
+    bookworm-base:
+        image: ghcr.io/fixposition/fixposition-sdk:bookworm-base
+        command: tail -f
+    bookworm-ci:
+        image: ghcr.io/fixposition/fixposition-sdk:bookworm-ci
+        command: tail -f
+    bookworm-dev:
+        image: ghcr.io/fixposition/fixposition-sdk:bookworm-dev
         volumes:
             # Bash config
             - ../.devcontainer/.bashrc:/home/fpsdk/.bashrc
@@ -42,27 +49,37 @@ services:
 
     # ----- ROS1 -------------------------------------------------------------------------------------------------------
 
-    noetic-base:
+    build-noetic-base:
         image: ghcr.io/fixposition/fixposition-sdk:noetic-base
         build:
             context: ..
             dockerfile: docker/Dockerfile.noetic-base
         command: tail -f
-    noetic-ci:
+    build-noetic-ci:
         image: ghcr.io/fixposition/fixposition-sdk:noetic-ci
         build:
             context: ..
             dockerfile: docker/Dockerfile.noetic-ci
         depends_on:
-            - noetic-base
+            - build-noetic-base
         command: tail -f
-    noetic-dev:
+    build-noetic-dev:
         image: ghcr.io/fixposition/fixposition-sdk:noetic-dev
         build:
             context: ..
             dockerfile: docker/Dockerfile.noetic-dev
         depends_on:
-            - noetic-base
+            - build-noetic-base
+        command: tail -f
+
+    noetic-base:
+        image: ghcr.io/fixposition/fixposition-sdk:noetic-base
+        command: tail -f
+    noetic-ci:
+        image: ghcr.io/fixposition/fixposition-sdk:noetic-ci
+        command: tail -f
+    noetic-dev:
+        image: ghcr.io/fixposition/fixposition-sdk:noetic-dev
         volumes:
             - ../.devcontainer/.bashrc:/home/fpsdk/.bashrc
             - ../.devcontainer/.bash_logout:/home/fpsdk/.bash_logout
@@ -76,27 +93,37 @@ services:
 
     # ----- ROS2 -------------------------------------------------------------------------------------------------------
 
-    humble-base:
+    build-humble-base:
         image: ghcr.io/fixposition/fixposition-sdk:humble-base
         build:
             context: ..
             dockerfile: docker/Dockerfile.humble-base
         command: tail -f
-    humble-ci:
+    build-humble-ci:
         image: ghcr.io/fixposition/fixposition-sdk:humble-ci
         build:
             context: ..
             dockerfile: docker/Dockerfile.humble-ci
         depends_on:
-            - humble-base
+            - build-humble-base
         command: tail -f
-    humble-dev:
+    build-humble-dev:
         image: ghcr.io/fixposition/fixposition-sdk:humble-dev
         build:
             context: ..
             dockerfile: docker/Dockerfile.humble-dev
+        command: tail -f
         depends_on:
-            - humble-base
+            - build-humble-base
+    humble-base:
+        image: ghcr.io/fixposition/fixposition-sdk:humble-base
+        command: tail -f
+
+    humble-ci:
+        image: ghcr.io/fixposition/fixposition-sdk:humble-ci
+        command: tail -f
+    humble-dev:
+        image: ghcr.io/fixposition/fixposition-sdk:humble-dev
         volumes:
             - ../.devcontainer/.bashrc:/home/fpsdk/.bashrc
             - ../.devcontainer/.bash_logout:/home/fpsdk/.bash_logout
@@ -108,27 +135,37 @@ services:
         hostname: fpsdk-humble-dev-${USER}
         command: tail -f
 
-    jazzy-base:
+
+    build-jazzy-base:
         image: ghcr.io/fixposition/fixposition-sdk:jazzy-base
         build:
             context: ..
             dockerfile: docker/Dockerfile.jazzy-base
         command: tail -f
-    jazzy-ci:
+    build-jazzy-ci:
         image: ghcr.io/fixposition/fixposition-sdk:jazzy-ci
         build:
             context: ..
             dockerfile: docker/Dockerfile.jazzy-ci
         depends_on:
-            - jazzy-base
+            - build-jazzy-base
         command: tail -f
-    jazzy-dev:
+    build-jazzy-dev:
         image: ghcr.io/fixposition/fixposition-sdk:jazzy-dev
         build:
             context: ..
             dockerfile: docker/Dockerfile.jazzy-dev
         depends_on:
-            - jazzy-base
+            - build-jazzy-base
+
+    jazzy-base:
+        image: ghcr.io/fixposition/fixposition-sdk:jazzy-base
+        command: tail -f
+    jazzy-ci:
+        image: ghcr.io/fixposition/fixposition-sdk:jazzy-ci
+        command: tail -f
+    jazzy-dev:
+        image: ghcr.io/fixposition/fixposition-sdk:jazzy-dev
         volumes:
             - ../.devcontainer/.bashrc:/home/fpsdk/.bashrc
             - ../.devcontainer/.bash_logout:/home/fpsdk/.bash_logout


### PR DESCRIPTION
By separating the docker image build from using the image, the vscode devcontainer will pull the image instead of locally building it.
