### PR TITLE
Cleanup and extend fpsdk::common::gnss stuff, docu, cosmetics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
               run: |
                   git config --global --add safe.directory ${GITHUB_WORKSPACE}
                   ./docker/ci.sh
+            - name: Artefacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: fpsdk_common_versions_trixie
+                  path: build/trixie-ci_build_toplevel_release_noros/*/*_versions.txt
 
     ci-fpsdk-noetic:
         runs-on: ubuntu-latest
@@ -39,6 +44,11 @@ jobs:
               run: |
                   git config --global --add safe.directory ${GITHUB_WORKSPACE}
                   ./docker/ci.sh
+            - name: Artefacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: fpsdk_common_versions_noetic
+                  path: build/noetic-ci_build_toplevel_release_ros1/*/*_versions.txt
 
     ci-fpsdk-humble:
         runs-on: ubuntu-latest
@@ -54,6 +64,11 @@ jobs:
               run: |
                   git config --global --add safe.directory ${GITHUB_WORKSPACE}
                   ./docker/ci.sh
+            - name: Artefacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: fpsdk_common_versions_humble
+                  path: build/humble-ci_build_toplevel_release_ros2/*/*_versions.txt
 
     ci-fpsdk-jazzy:
         runs-on: ubuntu-latest
@@ -69,6 +84,11 @@ jobs:
               run: |
                   git config --global --add safe.directory ${GITHUB_WORKSPACE}
                   ./docker/ci.sh
+            - name: Artefacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: fpsdk_common_versions_jazzy
+                  path: build/jazzy-ci_build_toplevel_release_ros2/*/*_versions.txt
 
     ci-images:
         runs-on: ubuntu-latest
@@ -123,6 +143,17 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            ##### Get artefacts from build jobs
+
+            - name: Get build artefacts
+              uses: actions/download-artifact@v5
+              with:
+                  path: build-artefacts  # See Doxyfile and Makefile
+              # We'll get:
+              #     build-artefacts/fpsdk_common_versions_trixie/fpsdk_common/fpsdk_common_versions.txt
+              #     build-artefacts/fpsdk_common_versions_jazzy/fpsdk_common/fpsdk_common_versions.txt
+              #     ...
+
             ##### Generate HTML content
 
             - name: Build documentation
@@ -141,8 +172,8 @@ jobs:
 
             ##### Archive generated HTML as artefacts
 
-            # https://github.com/actions/upload-pages-artifact (This, not actions/upload-artifact, wich doesn't work for
-            # pages deployment. Both actions make the artefact show up as a job artefact.
+            # https://github.com/actions/upload-pages-artifact (This, not actions/upload-artifact, which doesn't work
+            # for pages deployment. Both actions make the artefact show up as a job artefact.
             - name: Upload pages artefact
               uses: actions/upload-pages-artifact@v3
               with:

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,8 @@ $(BUILD_DIR)/.make-doc: $(BUILD_DIR)/.make-build fpsdk_doc/Doxyfile
             cat fpsdk_doc/Doxyfile; \
             echo "PROJECT_NUMBER = $$(cat $(BUILD_DIR)/FPSDK_VERSION_STRING || echo 'unknown revision')"; \
             echo "OUTPUT_DIRECTORY = $(BUILD_DIR)"; \
-			echo "EXAMPLE_PATH += $(BUILD_DIR)/helpscreens"; \
+            echo "EXAMPLE_PATH += $(BUILD_DIR)/helpscreens"; \
+            if [ -d build-artefacts ]; then echo "EXAMPLE_PATH += build-artefacts"; fi; \
         ) | $(DOXYGEN) -
 	$(V)$(TOUCH) $@
 

--- a/docker/Dockerfile.humble-base
+++ b/docker/Dockerfile.humble-base
@@ -7,11 +7,11 @@
 #
 ########################################################################################################################
 
-# ROS Humble Hawksbill (LTS until May 2027) base image (Ubuntu 22.04.6 LTS "Jammy")
+# ROS Humble Hawksbill (LTS until May 2027) base image (Ubuntu 22.04 LTS "Jammy")
 FROM ros:humble-ros-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04) base image with minimal stuff required to build"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04 Jammy) base image with minimal stuff required to build"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.humble-ci
+++ b/docker/Dockerfile.humble-ci
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:humble-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04) image for Github CI jobs"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04 Jammy) image for Github CI jobs"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.humble-dev
+++ b/docker/Dockerfile.humble-dev
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:humble-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04) image for vscode devcontainer"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04 Jammy) image for vscode devcontainer"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.humble-run
+++ b/docker/Dockerfile.humble-run
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:humble-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04) image with pre-built binaries"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Humble (Ubuntu 22.04 Jammy) image with pre-built binaries"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.jazzy-base
+++ b/docker/Dockerfile.jazzy-base
@@ -7,11 +7,11 @@
 #
 ########################################################################################################################
 
-# ROS Jazzy Jalisco (LTS until May 2029) base image (Ubuntu 24.04.6 LTS "Noble")
+# ROS Jazzy Jalisco (LTS until May 2029) base image (Ubuntu 24.04 LTS "Noble")
 FROM ros:jazzy-ros-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04) base image with minimal stuff required to build"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04 Noble) base image with minimal stuff required to build"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.jazzy-ci
+++ b/docker/Dockerfile.jazzy-ci
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:jazzy-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04) image for Github CI jobs"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04 Noble) image for Github CI jobs"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.jazzy-dev
+++ b/docker/Dockerfile.jazzy-dev
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:jazzy-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04) image for vscode devcontainer"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04 Noble) image for vscode devcontainer"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.jazzy-run
+++ b/docker/Dockerfile.jazzy-run
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:jazzy-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04) image with pre-built binaries"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Jazzy (Ubuntu 24.04 Noble) image with pre-built binaries"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.noetic-base
+++ b/docker/Dockerfile.noetic-base
@@ -10,7 +10,7 @@
 # ROS Noetic (until May 2025) base image (Ubuntu 20.04.6 LTS "Focal")
 FROM ros:noetic-ros-base
 
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04) base image with minimal stuff required to build"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04 Focal) base image with minimal stuff required to build"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 ENV FPSDK_IMAGE=noetic-base

--- a/docker/Dockerfile.noetic-ci
+++ b/docker/Dockerfile.noetic-ci
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:noetic-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04) base image for Github CI jobs"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04 Focal) base image for Github CI jobs"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.noetic-dev
+++ b/docker/Dockerfile.noetic-dev
@@ -9,7 +9,7 @@
 
 FROM ghcr.io/fixposition/fixposition-sdk:noetic-base
 
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04) image for vscode devcontainer"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04 Focal) image for vscode devcontainer"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 ENV FPSDK_IMAGE=noetic-dev

--- a/docker/Dockerfile.noetic-run
+++ b/docker/Dockerfile.noetic-run
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:noetic-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04) image with pre-built binaries"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: ROS Noetic (Ubuntu 20.04 Focal) image with pre-built binaries"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.trixie-base
+++ b/docker/Dockerfile.trixie-base
@@ -11,7 +11,7 @@
 FROM debian:trixie
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian Trixie base image with minimal stuff required to build"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian Trixie 13 base image with minimal stuff required to build"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.trixie-ci
+++ b/docker/Dockerfile.trixie-ci
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:trixie-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian Trixie image for Github CI jobs"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian 13 Trixie image for Github CI jobs"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.trixie-dev
+++ b/docker/Dockerfile.trixie-dev
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:trixie-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian Trixie image for vscode devcontainer"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian 13 Trixie image for vscode devcontainer"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/docker/Dockerfile.trixie-run
+++ b/docker/Dockerfile.trixie-run
@@ -10,7 +10,7 @@
 FROM ghcr.io/fixposition/fixposition-sdk:trixie-base
 
 # Metadata for github packages
-LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian Trixie image with pre-built binaries"
+LABEL org.opencontainers.image.description="Fixposition SDK docker image: Debian 13 Trixie image with pre-built binaries"
 LABEL org.opencontainers.image.source=https://github.com/fixposition
 
 # Variables used in our Docker build and CI scripts

--- a/examples/fusion_epoch/fusion_epoch.cpp
+++ b/examples/fusion_epoch/fusion_epoch.cpp
@@ -125,21 +125,21 @@ int main(int /*argc*/, char** /*argv*/)
     // The collector of messages
     CollectedMsgs collected_msgs;
     while (parser.Process(msg)) {
-        DEBUG("Message %-s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.data_.size());
+        DEBUG("Message %-s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.Size());
         bool msg_ok = true;
 
         // Collect FP_A-ODOMETRY
         if (msg.name_ == FpaOdometryPayload::MSG_NAME) {
-            msg_ok = collected_msgs.fpa_odometry_.SetFromMsg(msg.data_.data(), msg.data_.size());
+            msg_ok = collected_msgs.fpa_odometry_.SetFromMsg(msg.Data(), msg.Size());
         }
         // Collect FP_A-ODOMSTATUS
         else if (msg.name_ == FpaOdomstatusPayload::MSG_NAME) {
-            msg_ok = collected_msgs.fpa_odomstatus_.SetFromMsg(msg.data_.data(), msg.data_.size());
+            msg_ok = collected_msgs.fpa_odomstatus_.SetFromMsg(msg.Data(), msg.Size());
         }
         // FP_A-EOE: Check if it the *fusion* end of epoch, otherwise ignore
         else if (msg.name_ == FpaEoePayload::MSG_NAME) {
             FpaEoePayload fpa_eoe;
-            msg_ok = fpa_eoe.SetFromMsg(msg.data_.data(), msg.data_.size());
+            msg_ok = fpa_eoe.SetFromMsg(msg.Data(), msg.Size());
             if (fpa_eoe.epoch == FpaEpoch::FUSION) {
                 // Add it to the collection and process the data
                 collected_msgs.fpa_eoe_ = fpa_eoe;
@@ -155,7 +155,7 @@ int main(int /*argc*/, char** /*argv*/)
         if (!msg_ok) {
             msg.MakeInfo();
             WARNING("Failed decoding %s: %s", msg.name_.c_str(), msg.info_.c_str());
-            // DEBUG_HEXDUMP(msg.data_.data(), msg.data_.size(), NULL, NULL);  // Hexdump of the raw message data
+            // DEBUG_HEXDUMP(msg.Data(), msg.Size(), NULL, NULL);  // Hexdump of the raw message data
         }
     }
 

--- a/examples/parser_intro/parser_intro.cpp
+++ b/examples/parser_intro/parser_intro.cpp
@@ -144,8 +144,8 @@ int main(int /*argc*/, char** /*argv*/)
     // documentation.
     ParserMsg msg;
     while (parser.Process(msg)) {
-        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.data_.size());
-        // DEBUG_HEXDUMP(msg.data_.data(), msg.data_.size(), NULL, NULL);  // Hexdump of the raw message data
+        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.Size());
+        // DEBUG_HEXDUMP(msg.Data(), msg.Size(), NULL, NULL);  // Hexdump of the raw message data
     }
     // This should print the following output:
     //
@@ -182,8 +182,8 @@ int main(int /*argc*/, char** /*argv*/)
         WARNING("Parser overflow, SAMPLE_DATA_2 is too large!");
     }
     while (parser.Process(msg)) {
-        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.data_.size());
-        // DEBUG_HEXDUMP(msg.data_.data(), msg.data_.size(), NULL, NULL);  // Hexdump of the raw message data
+        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.Size());
+        // DEBUG_HEXDUMP(msg.Data(), msg.Size(), NULL, NULL);  // Hexdump of the raw message data
     }
     // This should print the following output:
     //
@@ -205,8 +205,8 @@ int main(int /*argc*/, char** /*argv*/)
     // a valid message:
     INFO("Flushing parser");
     while (parser.Flush(msg)) {
-        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.data_.size());
-        DEBUG_HEXDUMP(msg.data_.data(), msg.data_.size(), NULL, NULL);
+        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.Size());
+        DEBUG_HEXDUMP(msg.Data(), msg.Size(), NULL, NULL);
     }
     // This should print:
     //
@@ -237,10 +237,10 @@ int main(int /*argc*/, char** /*argv*/)
     while (parser.Process(msg)) {
         // Is it a FP_A-ODOMETRY?
         if (msg.name_ == FpaOdometryPayload::MSG_NAME) {
-            INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.data_.size());
+            INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.Size());
             // We can now try to decode it
             FpaOdometryPayload payload;
-            if (payload.SetFromMsg(msg.data_.data(), msg.data_.size())) {
+            if (payload.SetFromMsg(msg.Data(), msg.Size())) {
                 INFO("Decode OK");
             }
             // Decoding failed
@@ -289,11 +289,11 @@ int main(int /*argc*/, char** /*argv*/)
         }
         // Ignore invalid FP_A-ODOMETRY messages
         FpaOdometryPayload payload;
-        if (!payload.SetFromMsg(msg.data_.data(), msg.data_.size())) {
+        if (!payload.SetFromMsg(msg.Data(), msg.Size())) {
             continue;
         }
 
-        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.data_.size());
+        INFO("Message %-20s (size %" PRIuMAX " bytes)", msg.name_.c_str(), msg.Size());
 
         // Some the message fields are optional and in principle any field can be a "null" (empty) field. It is highly
         // recommended to *always* check if the desired fields are valid.

--- a/fpsdk_apps/fpltool/fpltool_extract.cpp
+++ b/fpsdk_apps/fpltool/fpltool_extract.cpp
@@ -156,7 +156,7 @@ bool DoExtract(const FplToolOptions& opts)
 
     // Close output files
     for (auto& entry : output_files) {
-        const std::string path = entry.second->GetPath();
+        const std::string path = entry.second->Path();
         entry.second->Close();
         const double raw_size = FileSize(path) / 1024.0 / 1024.0;
         if (ok) {

--- a/fpsdk_apps/parsertool/parsertool.cpp
+++ b/fpsdk_apps/parsertool/parsertool.cpp
@@ -276,7 +276,7 @@ class ParserTool
     {
         const auto output_file = Sprintf("%06" PRIuMAX "_%s.bin", msg.seq_, msg.name_.c_str());
         std::ofstream output(output_file, std::ios::binary);
-        output.write((const char*)msg.data_.data(), msg.data_.size());
+        output.write((const char*)msg.Data(), msg.Size());
         output.close();
     }
 
@@ -297,12 +297,11 @@ class ParserTool
         }
 
         if (opts_.stdout_) {
-            std::fwrite(msg.data_.data(), msg.data_.size(), 1, stdout);
+            std::fwrite(msg.Data(), msg.Size(), 1, stdout);
         } else {
             msg.MakeInfo();
             std::printf("message %06" PRIuMAX " %8" PRIuMAX " %5" PRIuMAX " %-8s %-30s %s\n", msg.seq_, offs,
-                msg.data_.size(), ProtocolStr(msg.proto_), msg.name_.c_str(),
-                msg.info_.empty() ? "-" : msg.info_.c_str());
+                msg.Size(), ProtocolStr(msg.proto_), msg.name_.c_str(), msg.info_.empty() ? "-" : msg.info_.c_str());
             if (hexdump) {
                 for (auto& line : HexDump(msg.data_)) {
                     std::printf("%s\n", line.c_str());
@@ -314,7 +313,7 @@ class ParserTool
         }
 
         stats_.Update(msg);
-        offs_ += msg.data_.size();
+        offs_ += msg.Size();
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/fpsdk_apps/parsertool/parsertool_doc.hpp
+++ b/fpsdk_apps/parsertool/parsertool_doc.hpp
@@ -42,7 +42,7 @@ namespace parsertool {
     <b>Print info on all messages found in a file:</b>
 
     @verbatim
-    $ parsertool fpsdk_common/test/data/mixed.bin
+    $ parsertool fpsdk_common/test/data/test_data_mixed.bin
     @endverbatim
 
     Outputs:

--- a/fpsdk_common/CMakeLists.txt
+++ b/fpsdk_common/CMakeLists.txt
@@ -74,6 +74,9 @@ else()
     endif()
 endif()
 
+fpsdk_save_versions(FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_versions.txt
+    PACKAGES CMAKE Boost yaml-cpp ZLIB Eigen3 nlohmann_json OpenSSL PROJ)
+
 
 # SHARED LIBRARY =======================================================================================================
 

--- a/fpsdk_common/cmake/setup.cmake
+++ b/fpsdk_common/cmake/setup.cmake
@@ -121,3 +121,25 @@ message(STATUS "fpsdk: FPSDK_VERSION_STRING=${FPSDK_VERSION_STRING}")
 
 
 ########################################################################################################################
+
+macro(fpsdk_save_versions)
+    set(options)
+    set(one_value_args FILE)
+    set(multi_value_args PACKAGES)
+    cmake_parse_arguments(FPSDK_SAVE_VERSIONS "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+    list(SORT FPSDK_SAVE_VERSIONS_PACKAGES)
+    list(REMOVE_DUPLICATES FPSDK_SAVE_VERSIONS_PACKAGES)
+
+    message(STATUS "fpsdk: Saving versions to ${FPSDK_SAVE_VERSIONS_FILE}")
+    write_file(${FPSDK_SAVE_VERSIONS_FILE} "# Versions for ${PROJECT_NAME}")
+
+    foreach(_pkg ${FPSDK_SAVE_VERSIONS_PACKAGES})
+        string(SUBSTRING "${_pkg}                    " 0 20 _name)
+        write_file(${FPSDK_SAVE_VERSIONS_FILE} "${_name} ${${_pkg}_VERSION}" APPEND)
+    endforeach()
+
+endmacro()
+
+
+########################################################################################################################

--- a/fpsdk_common/include/fpsdk_common/ext/eigen_core.hpp
+++ b/fpsdk_common/include/fpsdk_common/ext/eigen_core.hpp
@@ -7,11 +7,11 @@
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"  // NOLINT
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 #  pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #endif
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Wclass-memaccess"  // NOLINT
 #include <Eigen/Core>
 #pragma GCC diagnostic pop
 // For older Eigen (e.g. 3.3.7, which we have in fusion-dev-env and on the sensor), we unfortunately have to disable

--- a/fpsdk_common/include/fpsdk_common/ext/eigen_geometry.hpp
+++ b/fpsdk_common/include/fpsdk_common/ext/eigen_geometry.hpp
@@ -7,12 +7,11 @@
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Wclass-memaccess"  // NOLINT
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 #  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #  pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #endif
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
 #include <Eigen/Geometry>
 #pragma GCC diagnostic pop
 // See exmplanation in eigen_core.hpp

--- a/fpsdk_common/include/fpsdk_common/fpl.hpp
+++ b/fpsdk_common/include/fpsdk_common/fpl.hpp
@@ -312,7 +312,7 @@ struct LogStatus
     uint32_t log_time_posix_ = 0;  //!< Approximate time
     std::string log_time_iso_;     //!< Approximate time
     int8_t pos_source_ = 0;        //!< Approximate sensor position source (see POS_SOURCE_... below)
-    int8_t pos_fix_type_ = 0;      //!< Approximate sensor position fix type (see fpsdk::common::gnss::GnssFixType)
+    int8_t pos_fix_type_ = 0;      //!< Approximate sensor position fix type (see fpsdk::common::gnss::FixType)
     double pos_lat_ = 0.0;         //!< Approximate sensor position latitude [deg]
     double pos_lon_ = 0.0;         //!< Approximate sensor position longitude [deg]
     double pos_height_ = 0.0;      //!< Approximate sensor position height [m]

--- a/fpsdk_common/include/fpsdk_common/gnss.hpp
+++ b/fpsdk_common/include/fpsdk_common/gnss.hpp
@@ -26,6 +26,8 @@
 /* EXTERNAL */
 
 /* PACKAGE */
+#include "parser/nmea.hpp"
+#include "parser/ubx.hpp"
 #include "types.hpp"
 
 namespace fpsdk {
@@ -39,7 +41,7 @@ namespace gnss {
 /**
  * @brief GNSS fix types
  */
-enum class GnssFixType : uint8_t
+enum class FixType : uint8_t
 {  // clang-format off
     UNKNOWN        =  0,  //!< Unknown fix
     NOFIX          =  1,  //!< No fix
@@ -61,31 +63,40 @@ enum class GnssFixType : uint8_t
  *
  * @returns a concise and unique string for the fix types, "?" for bad values
  */
-const char* GnssFixTypeStr(const GnssFixType fix_type);
+const char* FixTypeStr(const FixType fix_type);
 
 /**
  * @brief GNSS
  */
 enum class Gnss : uint8_t
-{  // clang-format off
-    UNKNOWN = 0,    //!< Unknown/unspecified GNSS
-    GPS     = 'G',  //!< GPS
-    SBAS    = 'S',  //!< SBAS
-    GAL     = 'E',  //!< Galileo
-    BDS     = 'C',  //!< BeiDou
-    QZSS    = 'J',  //!< QZSS
-    GLO     = 'R',  //!< GLONASS
-    NAVIC   = 'I',  //!< NavIC (IRNSS)
-};  // clang-format on
+{
+    UNKNOWN = 0,  //!< Unknown/unspecified GNSS
+    GPS,          //!< GPS           (G)
+    SBAS,         //!< SBAS          (S)
+    GAL,          //!< Galileo       (E)
+    BDS,          //!< BeiDou        (C)
+    QZSS,         //!< QZSS          (J)
+    GLO,          //!< GLONASS       (R)
+    NAVIC,        //!< NavIC (IRNSS) (I)
+};
 
 /**
  * @brief Stringify GNSS
  *
  * @param[in]  gnss  The GNSS
  *
- * @returns a concise and unique string for the GNSS, "?" for bad values
+ * @returns a concise and unique string for the GNSS ("GPS", "GAL", etc.), "?" for bad values
  */
 const char* GnssStr(const Gnss gnss);
+
+/**
+ * @brief Get GNSS char
+ *
+ * @param[in]  gnss  The GNSS
+ *
+ * @returns the character for the GNSS ('G', 'E', etc.), '?' for bad values
+ */
+char GnssChar(const Gnss gnss);
 
 /**
  * @brief Signals
@@ -93,33 +104,40 @@ const char* GnssStr(const Gnss gnss);
 enum class Signal : uint8_t
 {  // clang-format off
     UNKNOWN = 0,  //!< Unknown/unspecified signal
-    BDS_B1C,      //!< BeiDou B1c signal    (B1 Cp and B1 Cd)
-    BDS_B1I,      //!< BeiDou B1I signal    (B1I D1 and B1I D2)
-    BDS_B2A,      //!< BeiDou B2a signal    (B2 ap and B2 ad)
-    BDS_B2I,      //!< BeiDou B2I signal    (B2I D1 and B2I D2)
-    BDS_B3I,      //!< BeiDou B3I signal    (B3I D1 and B3I D2)
-    GAL_E1,       //!< Galileo E1 signal    (E1 C and E1 B)
-    GAL_E5A,      //!< Galileo E5a signal   (E5 aI and E5 aQ)
-    GAL_E5B,      //!< Galileo E5b signal   (E5 bI and E5 bQ)
-    GAL_E6,       //!< Galileo E6 signal    (E6A, E6B, adn E6C)
-    GLO_L1OF,     //!< GLONASS L1 OF signal
-    GLO_L2OF,     //!< GLONASS L2 OF signal
-    GPS_L1CA,     //!< GPS L1 C/A signal
-    GPS_L2C,      //!< GPS L2 C signal      (L2 CL and L2 CM)
-    GPS_L5,       //!< GPS L5 signal        (L5 I and L5 Q)
-    QZSS_L1CA,    //!< QZSS L1 C/A signal
-    QZSS_L1S,     //!< QZSS L1 S (SAIF) signal
-    QZSS_L2C,     //!< QZSS L2 C signal     (L2 CL and L2 CM)
-    QZSS_L5,      //!< QZSS L5 signal       (L5 I and L5 Q)
-    SBAS_L1CA,    //!< SBAS L1 C/A signal
-    NAVIC_L5A,    //!< NavIC L5 A
+    // GPS
+    GPS_L1CA,     //!< [L1] GPS L1 C/A signal
+    GPS_L2C,      //!< [L2] GPS L2 C signal      (L2 CL and L2 CM)
+    GPS_L5,       //!< [L5] GPS L5 signal        (L5 I and L5 Q)
+    // SBAS
+    SBAS_L1CA,    //!< [L1] SBAS L1 C/A signal
+    // GAL
+    GAL_E1,       //!< [L1] Galileo E1 signal    (E1 C and E1 B)
+    GAL_E6,       //!< [E6] Galileo E6 signal    (E6A, E6B, and E6C)
+    GAL_E5B,      //!< [L2] Galileo E5b signal   (E5 bI and E5 bQ)
+    GAL_E5A,      //!< [L5] Galileo E5a signal   (E5 aI and E5 aQ)
+    // BDS
+    BDS_B1C,      //!< [L1] BeiDou B1c signal    (B1 Cp and B1 Cd)
+    BDS_B1I,      //!< [L1] BeiDou B1I signal    (B1I D1 and B1I D2)
+    BDS_B3I,      //!< [E6] BeiDou B3I signal    (B3I D1 and B3I D2)
+    BDS_B2I,      //!< [L2] BeiDou B2I signal    (B2I D1 and B2I D2)
+    BDS_B2A,      //!< [L5] BeiDou B2a signal    (B2 ap and B2 ad)
+    // QZSS
+    QZSS_L1CA,    //!< [L1] QZSS L1 C/A signal
+    QZSS_L1S,     //!< [L1] QZSS L1 S (SAIF) signal
+    QZSS_L2C,     //!< [L2] QZSS L2 C signal     (L2 CL and L2 CM)
+    QZSS_L5,      //!< [L5] QZSS L5 signal       (L5 I and L5 Q)
+    // GLO
+    GLO_L1OF,     //!< [L1] GLONASS L1 OF signal
+    GLO_L2OF,     //!< [L2] GLONASS L2 OF signal
+    // NAVIC
+    NAVIC_L5A,    //!< [L5] NavIC L5 A
 };  // clang-format on
 
 /**
  * @brief Stringify signal
  *
  * @param[in]  signal  The signal
- * @param[in]  kurz   Get short string (for example, "L1CA" instead of "GPS_L1CA")
+ * @param[in]  kurz    Get short string (for example, "L1CA" instead of "GPS_L1CA")
  *
  * @returns a concise and unique string for the signal, "?" for bad values
  */
@@ -131,10 +149,10 @@ const char* SignalStr(const Signal signal, const bool kurz = false);
 enum class Band : uint8_t
 {
     UNKNOWN = 0,  //!< Unknown/unspecified band
-    L1,           //!< L1 band (~1.5GHz)
-    L2,           //!< L2 band (~1.2GHz)
-    E6,           //!< E6 band (~1.3GHz)
-    L5,           //!< L5 band (~1.1GHz)
+    L1,           //!< L1 (E1) band (~1.5GHz)
+    E6,           //!< E6 band      (~1.3GHz)
+    L2,           //!< L2 band      (~1.2GHz)
+    L5,           //!< L5 (E5) band (~1.1GHz)
 };
 
 /**
@@ -147,13 +165,137 @@ enum class Band : uint8_t
 const char* BandStr(const Band band);
 
 /**
+ * @brief Signal use
+ */
+enum class SigUse : uint8_t
+{
+    UNKNOWN = 0,  //!< Unknown or unspecified use of the signal
+    NONE,         //!< Signal not used
+    SEARCH,       //!< Signal is being searched
+    ACQUIRED,     //!< Signal was acquired
+    UNUSABLE,     //!< Signal tracked but unused
+    CODELOCK,     //!< Signal tracked and code locked
+    CARRLOCK,     //!< Signal tracked and carrier locked
+};
+
+/**
+ * @brief Stringify signal use
+ *
+ * @param[in]  use  The signal use
+ *
+ * @returns a concise and unique string for the signal use, "?" for bad values
+ */
+const char* SigUseStr(const SigUse use);
+
+/**
+ * @brief Signal correction data availability
+ */
+enum class SigCorr : uint8_t
+{
+    UNKNOWN = 0,  //!< Unknown or unspecified corrections
+    NONE,         //!< No corrections available
+    SBAS,         //!< SBAS (DGNSS) corrections available
+    BDS,          //!< BeiDou (DGNSS) corrections available
+    RTCM2,        //!< RTCM v2 (DGNSS) corrections available
+    RTCM3_OSR,    //!< RTCM v3.x OSR type RTK corrections available
+    RTCM3_SSR,    //!< RTCM v3.x SSR type RTK corrections available
+    QZSS_SLAS,    //!< QZSS SLAS corrections available
+    SPARTN,       //!< SPARTN corrections available
+};
+
+/**
+ * @brief Stringify signal correction data availability
+ *
+ * @param[in]  corr  The signal correction data availability
+ *
+ * @returns a concise and unique string for the signal correction data availability, "?" for bad values
+ */
+const char* SigCorrStr(const SigCorr corr);
+
+/**
+ * @brief Ionosphere corrections
+ */
+enum class SigIono : uint8_t
+{
+    UNKNOWN = 0,  //!< Unknown or unspecified corrections
+    NONE,         //!< No corrections
+    KLOB_GPS,     //!< GPS style Klobuchar corrections
+    KLOB_BDS,     //!< BeiDou style Klobuchar corrections
+    SBAS,         //!< SBAS corrections
+    DUAL_FREQ,    //!< Dual frequency iono-free combination
+};
+
+/**
+ * @brief Stringify ionosphere corrections
+ *
+ * @param[in]  iono  The ionosphere corrections
+ *
+ * @returns a concise and unique string for the ionosphere corrections, "?" for bad values
+ */
+const char* SigIonoStr(const SigIono iono);
+
+/**
+ * @brief Signal health
+ */
+enum class SigHealth : uint8_t
+{
+    UNKNOWN = 0,  //!< Unknown or unspecified health
+    HEALTHY,      //!< Signal is healthy
+    UNHEALTHY,    //!< Signal is unhealthy
+};
+
+/**
+ * @brief Stringify signal health
+ *
+ * @param[in]  health  The signal health
+ *
+ * @returns a concise and unique string for the signal health, "?" for bad values
+ */
+const char* SigHealthStr(const SigHealth health);
+
+/**
+ * @brief Satellite orbit source
+ */
+enum class SatOrb : uint8_t  // clang-format off
+{
+    UNKNOWN = 0x00,  //!< Unknown
+    NONE    = 0x01,  //!< No orbit available
+    EPH     = 0x02,  //!< Ephemeris
+    ALM     = 0x04,  //!< Almanac
+    PRED    = 0x08,  //!< Predicted orbit
+    OTHER   = 0x10,  //!< Other, unspecified orbit source
+};  // clang-format on
+
+/**
+ * @brief Stringify satellite orbit source
+ *
+ * @param[in]  orb  The satellite orbit source
+ *
+ * @returns a concise and unique string for the satellite orbit source, "?" for bad values
+ */
+const char* SatOrbStr(const SatOrb orb);
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+/**
  * @brief Get frequency band for a signal
  *
- * @param[in]  signal   The signal
+ * @param[in]  signal  The signal
  *
  * @returns the frequency band for the signal
  */
 Band SignalToBand(const Signal signal);
+
+/**
+ * @brief Get GNSS for a signal
+ *
+ * @param[in]  signal  The signal
+ *
+ * @returns the GNSS for the signal
+ */
+Gnss SignalToGnss(const Signal signal);
+
+// ---------------------------------------------------------------------------------------------------------------------
 
 /**
  * @brief Satellite number (within a GNSS)
@@ -185,154 +327,148 @@ static constexpr SvNr INAVLID_SVNR =  0;  //!< Invalid satellite number (in any 
 /**
  * @brief Satellite ("sat"), consisting of GNSS and satellite number, suitable for indexing and sorting
  */
-using Sat = uint16_t;
+struct Sat
+{  // clang-format off
+    /**
+     * @brief Default ctor: invalid satellite (INVALID_SAT)
+     */
+    Sat() = default;
 
-/**
- * @brief Get "sat" from GNSS and satellite ID
- *
- * @note This does not do any range checking and it's up to the user to provide a valid satellite ID for the given GNSS.
- *
- * @param[in]  gnss  GNSS
- * @param[in]  svnr  Satellite ID
- *
- * @returns the "sat"
- */
-static constexpr Sat GnssSvNrToSat(const Gnss gnss, const SvNr svnr)
-{
-    return ((Sat)types::EnumToVal(gnss) << 8) | (Sat)svnr;
-}
+    /**
+     * @brief Ctor: from GNSS and satellite number
+     *
+     * @note This does not do any range checking and it's up to the user to provide a valid satellite ID for the given GNSS.
+     *
+     * @param[in]  gnss    GNSS
+     * @param[in]  svnr    Satellite number
+     */
+    Sat(const Gnss gnss, const SvNr svnr) : id_ { (uint16_t)(((uint16_t)types::EnumToVal(gnss) << 8) | (uint16_t)svnr) } {}
+
+    /**
+     * @brief Ctor: from string
+     *
+     * @note Invalid strings create an INVALID_SAT
+     *
+     * @param[in]  str  The string ("G03", "R22", "C12", ...)
+     */
+    Sat(const char* str);
+
+    /**
+     * @brief Get GNSS
+     *
+     * @returns the GNSS
+     */
+    inline Gnss GetGnss() const { return (Gnss)((id_ >> 8) & 0xff); }
+
+    /**
+     * @brief Get satellite number
+     *
+     * @returns the satellit nuber
+     */
+    inline SvNr GetSvNr() const { return id_ & 0xff; }
+
+    /**
+     * @brief Stringify satellite
+     *
+     * @returns a unique string identifying the satellite
+     */
+    const char* GetStr() const;
+
+    uint16_t id_ = 0x0000;  //!< Internal representation of Gnss+SvNr
+
+    inline bool operator< (const Sat& rhs) const { return id_ <  rhs.id_; } //!< Less-than operator
+    inline bool operator==(const Sat& rhs) const { return id_ == rhs.id_; } //!< Equal operator
+    inline bool operator!=(const Sat& rhs) const { return id_ != rhs.id_; } //!< Not equal operator
+    // See also std::hash<Sat> declaration at the end of this file
+};  // clang-format on
 
 /**
  * @brief Invalid "sat"
  *
  * @note This is not the only invalid combination of GNSS and satellite number!
  */
-static constexpr Sat INVALID_SAT = GnssSvNrToSat(Gnss::UNKNOWN, INAVLID_SVNR);
-
-/**
- * @brief Get GNSS from "sat"
- *
- * @param[in]  sat  The "sat"
- *
- * @returns the GNSS
- */
-static constexpr Gnss SatToGnss(const Sat sat)
-{
-    return (Gnss)((sat >> 8) & 0xff);
-}
-
-/**
- * @brief Get satellite nr from "sat"
- *
- * @param[in]  sat  The "sat"
- *
- * @returns the satellite nr
- */
-static constexpr SvNr SatToSvNr(const Sat sat)
-{
-    return sat & 0xff;
-}
+static constexpr Sat INVALID_SAT;
 
 // ---------------------------------------------------------------------------------------------------------------------
 
 /**
  * @brief Satellite plus frequency band and signal ("satsig"), suitable for indexing and sorting
  */
-using SatSig = uint32_t;
+struct SatSig
+{  // clang-format off
+    /**
+     * @brief Default ctor: invalid SatSig (INVALID_SATSIG)
+     */
+    SatSig() = default;
 
-/**
- * @brief Get "satsig" from components
- *
- * @note This does not do any range checking and it's up to the user to provide a valid satellite ID for the given GNSS.
- *
- * @param[in]  gnss    GNSS
- * @param[in]  svnr    Satellite ID
- * @param[in]  band    Frequency band
- * @param[in]  signal  Signal
- *
- * @returns the "satsig"
- */
-static constexpr SatSig GnssSvNrBandSignalToSatSig(
-    const Gnss gnss, const SvNr svnr, const Band band, const Signal signal)
-{
-    return ((SatSig)types::EnumToVal(gnss) << 24) | ((SatSig)svnr << 16) | ((SatSig)band << 8) | (SatSig)signal;
-}
+    /**
+     * @brief Ctor: create SatSig
+     *
+     * @note This does not do any range checking and it's up to the user to provide a valid satellite ID for the given GNSS.
+     *
+     * @param[in]  gnss    GNSS
+     * @param[in]  svnr    Satellite number
+     * @param[in]  band    Frequency band
+     * @param[in]  signal  Signal
+     */
+    SatSig(const Gnss gnss, const SvNr svnr, const Band band, const Signal signal) : id_ { (uint32_t)(types::EnumToVal(gnss) << 24) | (uint32_t)(svnr << 16) | (uint32_t)(types::EnumToVal(band) << 8) | (uint32_t)types::EnumToVal(signal) } {}
 
-/**
- * @brief Invalid "satsig""
- *
- * @note This is not the only invalid combination of GNSS, satellite number, band and signal!
- */
-static constexpr SatSig INVALID_SATSIG =
-    GnssSvNrBandSignalToSatSig(Gnss::UNKNOWN, INAVLID_SVNR, Band::UNKNOWN, Signal::UNKNOWN);
+    /**
+     * @brief Ctor: create SatSig
+     *
+     * @note This does not do any range checking and it's up to the user to provide a valid satellite ID for the given GNSS.
+     *
+     * @param[in]  sat     Satellite (GNSS + satellite number)
+     * @param[in]  signal  Signal (implies band)
+     */
+    SatSig(const Sat sat, const Signal signal) : id_ { (uint32_t)(((uint32_t)sat.id_ << 16) | ((uint32_t)types::EnumToVal(SignalToBand(signal)) << 8) | ((uint32_t)types::EnumToVal(signal))) } {}
 
-/**
- * @brief Get GNSS from "satsig"
- *
- * @param[in]  satsig  The "satsig"
- *
- * @returns the GNSS
- */
-static constexpr Gnss SatSigToGnss(const SatSig satsig)
-{
-    return (Gnss)((satsig >> 24) & 0xff);
-}
+    /**
+     * @brief Get satellite
+     *
+     * @returns the satellite
+     */
+    inline Sat GetSat() const { return { GetGnss(), GetSvNr() }; }
 
-/**
- * @brief Get satellite nr from "satsig"
- *
- * @param[in]  satsig  The "satsig"
- *
- * @returns the satellite nr
- */
-static constexpr SvNr SatSigToSvNr(const SatSig satsig)
-{
-    return (SvNr)((satsig >> 16) & 0xff);
-}
+    /**
+     * @brief Get GNSS
+     *
+     * @returns the GNSS
+     */
+    inline Gnss GetGnss() const { return (Gnss)((id_ >> 24) & 0xff); }
 
-/**
- * @brief Get frequency band from "satsig"
- *
- * @param[in]  satsig  The "satsig"
- *
- * @returns the frequency band
- */
-static constexpr Band SatSigToBand(const SatSig satsig)
-{
-    return (Band)((satsig >> 8) & 0xff);
-}
+    /**
+     * @brief Get satellite number
+     *
+     * @returns the satellite number
+     */
+    inline SvNr GetSvNr() const { return (SvNr)((id_ >> 16) & 0xff); }
 
-/**
- * @brief Get signal from "satsig"
- *
- * @param[in]  satsig  The "satsig"
- *
- * @returns the signal
- */
-static constexpr Signal SatSigToSignal(const SatSig satsig)
-{
-    return (Signal)(satsig & 0xff);
-}
+    /**
+     * @brief Get band
+     *
+     * @returns the band
+     */
+    inline Band GetBand() const { return (Band)((id_ >> 8) & 0xff); }
+
+    /**
+     * @brief Get signal
+     *
+     * @returns the signal
+     */
+    inline Signal GetSignal() const { return (Signal)(id_ & 0xff); }
+
+    uint32_t id_ = 0x00000000;  //!< Internal representation of Gnss+SvNr+Band+Signal
+
+    inline bool operator< (const SatSig& rhs) const { return id_ <  rhs.id_; } //!< Less-than operator
+    inline bool operator==(const SatSig& rhs) const { return id_ == rhs.id_; } //!< Equal operator
+    inline bool operator!=(const SatSig& rhs) const { return id_ != rhs.id_; } //!< Not equal operator
+    // See also std::hash<SatSig> declaration at the end of this file
+};  // clang-format on
+
+static constexpr SatSig INVALID_SATSIG;  //!< Invalid SatSig
 
 // ---------------------------------------------------------------------------------------------------------------------
-
-/**
- * @brief Stringify satellite
- *
- * @param[in]  sat  The satellite
- *
- * @returns a unique string identifying the satellite
- */
-const char* SatStr(const Sat sat);
-
-/**
- * @brief Satellite from string
- *
- * @param[in]  str  The string ("G03", "R22", "C12", ...)
- *
- * @returns the satellite (INVALID_SAT if str was invalid)
- */
-Sat StrSat(const char* str);
 
 /**
  * @brief Convert UBX gnssId to GNSS
@@ -363,8 +499,84 @@ Sat UbxGnssIdSvIdToSat(const uint8_t gnssId, const uint8_t svId);
  */
 Signal UbxGnssIdSigIdToSignal(const uint8_t gnssId, const uint8_t sigId);
 
+// ---------------------------------------------------------------------------------------------------------------------
+
+/**
+ * @brief Convert NMEA GGA quality to fix type
+ *
+ * @param[in]  quality  NMEA GGA quality
+ *
+ * @returns the fix type corresponding to the quality
+ */
+FixType NmeaQualityGgaToFixType(const parser::nmea::NmeaQualityGga quality);
+
+/**
+ * @brief Convert NMEA RMC/GNS mode to fix type
+ *
+ * @param[in]  mode  NMEA RMC/GNS mode
+ *
+ * @returns the fix type corresponding to the mode
+ */
+FixType NmeaModeRmcGnsToFixType(const parser::nmea::NmeaModeRmcGns mode);
+
+/**
+ * @brief Convert NMEA GLL/VTG mode to fix type
+ *
+ * @param[in]  mode  NMEA GLL/VTG mode
+ *
+ * @returns the fix type corresponding to the mode
+ */
+FixType NmeaModeGllVtgToFixType(const parser::nmea::NmeaModeGllVtg mode);
+
+/**
+ * @brief Convert NMEA system ID and satellite number to satellite
+ *
+ * @param[in]  systemId     NMEA system ID
+ * @param[in]  svId         NMEA satellite ID
+ * @param[in]  nmeaVersion  NMEA version
+ *
+ * @returns the satellite, INVALID_SAT for invalid systemId/svId
+ */
+Sat NmeaSystemIdSvIdToSat(const parser::nmea::NmeaSystemId systemId, const uint8_t svId,
+    const parser::nmea::NmeaVersion nmeaVersion = parser::nmea::NmeaVersion::V411);
+
+/**
+ * @brief Convert NMEA signal ID to signal
+ *
+ * @param[in]  signalId  NMEA signal ID
+ *
+ * @returns the signal
+ */
+Signal NmeaSignalIdToSignal(const parser::nmea::NmeaSignalId signalId);
+
 /* ****************************************************************************************************************** */
 }  // namespace gnss
 }  // namespace common
 }  // namespace fpsdk
+
+/**
+ * @brief Hasher for Sat (e.g. std::unordered_map)
+ */
+template <>
+struct std::hash<fpsdk::common::gnss::Sat>
+{
+    std::size_t operator()(const fpsdk::common::gnss::Sat& k) const
+    {
+        return k.id_;
+    }  //!< operator
+};
+
+/**
+ * @brief Hasher for SatSig (e.g. std::unordered_map)
+ */
+template <>
+struct std::hash<fpsdk::common::gnss::SatSig>
+{
+    std::size_t operator()(const fpsdk::common::gnss::SatSig& k) const
+    {
+        return k.id_;
+    }  //!< operator
+};
+
+/* ****************************************************************************************************************** */
 #endif  // __FPSDK_COMMON_GNSS_HPP__

--- a/fpsdk_common/include/fpsdk_common/math.hpp
+++ b/fpsdk_common/include/fpsdk_common/math.hpp
@@ -69,6 +69,8 @@ constexpr inline T RadToDeg(T radians)
  */
 struct DegMinSec
 {
+    DegMinSec() = default;  //!< Default ctor
+
     /**
      * @brief Set from fractional degrees
      *

--- a/fpsdk_common/include/fpsdk_common/parser.hpp
+++ b/fpsdk_common/include/fpsdk_common/parser.hpp
@@ -80,7 +80,7 @@
  *     // Run parser and print message name and size to the screen
  *     while (parser.Process(msg)) {
  *         msg.MakeInfo();  // Try to populate msg.info_
- *         INFO("Message %s, size %d (%s)", msg.name_.c_str(), (int)msg.data_.size(), msg.info_.c_str());
+ *         INFO("Message %s, size %d (%s)", msg.name_.c_str(), (int)msg.Size(), msg.info_.c_str());
  *     }
  * }
  *
@@ -88,7 +88,7 @@
  * // If there is anytghing, we should see only type OTHER "messages" here.
  * while (parser.Flush(msg)) {
  *     msg.MakeInfo();
- *     INFO("Message %s, size %d", msg.name_.c_str(), (int)msg.data_.size(), msg.info_.c_str());
+ *     INFO("Message %s, size %d", msg.name_.c_str(), (int)msg.Size(), msg.info_.c_str());
  * }
  * @endcode
  *

--- a/fpsdk_common/include/fpsdk_common/parser/types.hpp
+++ b/fpsdk_common/include/fpsdk_common/parser/types.hpp
@@ -100,7 +100,7 @@ struct ParserMsg
     std::string          name_;     //!< Name of the message
     mutable std::string  info_;     //!< Message (debug) info, default empty, call MakeInfo() to fill
     uint64_t             seq_ = 0;  //!< Message counter (starting at 1)
-    // clang-formt on
+    // clang-format on
 
     /**
      * @brief Make info_ field
@@ -109,12 +109,27 @@ struct ParserMsg
      * useful into the info_ field.
      */
     void MakeInfo() const;
+
+    /**
+     * @brief Get message raw data
+     *
+     * @returns a pointer to the message raw data
+     */ // clang-format off
+    inline const uint8_t* Data() const { return data_.data(); }  // clang-format on
+
+    /**
+     * @brief Get message raw size
+     *
+     * @returns the message raw size
+     */ // clang-format off
+    inline std::size_t Size() const { return data_.size(); }  // clang-format on
 };
 
 /**
  * @brief Parser statistics
  */
-struct ParserStats {
+struct ParserStats
+{
     uint64_t n_msgs_ = 0;    //!< Number of messages parsed
     uint64_t s_msgs_ = 0;    //!< Total size of messages parsed
     uint64_t n_fpa_ = 0;     //!< Number of Protocol::FP_A messages

--- a/fpsdk_common/include/fpsdk_common/parser/ubx.hpp
+++ b/fpsdk_common/include/fpsdk_common/parser/ubx.hpp
@@ -368,6 +368,8 @@ static constexpr uint8_t     UBX_NAV_SIG_MSGID              = 0x43;             
 static constexpr const char* UBX_NAV_SIG_STRID              = "UBX-NAV-SIG";            //!< UBX-NAV-SIG message name
 static constexpr uint8_t     UBX_NAV_SLAS_MSGID             = 0x42;                     //!< UBX-NAV-SLAS message ID
 static constexpr const char* UBX_NAV_SLAS_STRID             = "UBX-NAV-SLAS";           //!< UBX-NAV-SLAS message name
+static constexpr uint8_t     UBX_NAV_SOL_MSGID              = 0x01;                     //!< UBX-NAV-SOL message ID
+static constexpr const char* UBX_NAV_SOL_STRID              = "UBX-NAV-SOL";            //!< UBX-NAV-SOL message name
 static constexpr uint8_t     UBX_NAV_STATUS_MSGID           = 0x03;                     //!< UBX-NAV-STATUS message ID
 static constexpr const char* UBX_NAV_STATUS_STRID           = "UBX-NAV-STATUS";         //!< UBX-NAV-STATUS message name
 static constexpr uint8_t     UBX_NAV_SVIN_MSGID             = 0x3b;                     //!< UBX-NAV-SVIN message ID
@@ -607,7 +609,7 @@ struct UbxMsgInfo
 
 // @fp_codegen_begin{FPSDK_COMMON_PARSER_UBX_MSGINFO_HPP}
 using UbxClassesInfo = std::array<UbxMsgInfo, 15>;    //!< UBX classes lookup table
-using UbxMessagesInfo = std::array<UbxMsgInfo, 185>;  //!< UBX messages lookup table
+using UbxMessagesInfo = std::array<UbxMsgInfo, 186>;  //!< UBX messages lookup table
 // @fp_codegen_end{FPSDK_COMMON_PARSER_UBX_MSGINFO_HPP}
 
 /**
@@ -728,8 +730,8 @@ static constexpr uint8_t UBX_SIGID_NAVIC_L5A     =  0;      //!< NavIC L5 A
 //! UBX-ACK-ACK (version 0, output) payload
 struct UBX_ACK_ACK_V0_GROUP0  // clang-format off
 {
-    uint8_t clsId;                                    //!< Class ID of ack'ed message
-    uint8_t msgId;                                    //!< Message ID of ack'ed message
+    uint8_t clsId;           //!< Class ID of ack'ed message
+    uint8_t msgId;           //!< Message ID of ack'ed message
 };  // clang-format on
 
 // clang-format off
@@ -746,8 +748,8 @@ static constexpr std::size_t UBX_ACK_ACK_V0_SIZE                                
 //! UBX-ACK-NCK (version 0, output) payload
 struct UBX_ACK_NAK_V0_GROUP0  // clang-format off
 {
-    uint8_t clsId;                                    //!< Class ID of not-ack'ed message
-    uint8_t msgId;                                    //!< Message ID of not-ack'ed message
+    uint8_t clsId;           //!< Class ID of not-ack'ed message
+    uint8_t msgId;           //!< Message ID of not-ack'ed message
 };
 // clang-format on
 
@@ -1014,17 +1016,17 @@ static_assert(sizeof(UBX_ESF_MEAS_V0_GROUP2) == 4, "");
 
 // clang-format off
 static constexpr std::size_t UBX_ESF_MEAS_V0_MIN_SIZE                                               = sizeof(UBX_ESF_MEAS_V0_GROUP0) + UBX_FRAME_SIZE;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_MEAS_V0_FLAGS_TIMEMARKSENT_GET(const uint16_t flags)           { return flags & 0x03; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_MEAS_V0_FLAGS_TIMEMARKSENT(const uint16_t flags)               { return flags & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_MEAS_V0_FLAGS_TIMEMARKSENT_NONE                                = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_MEAS_V0_FLAGS_TIMEMARKSENT_EXT0                                = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_MEAS_V0_FLAGS_TIMEMARKSENT_EXT1                                = 2;  //!< @todo documentation
 static constexpr bool        UBX_ESF_MEAS_V0_FLAGS_CALIBTTAGVALID(const uint16_t flags)             { return (flags & 0x0008) == 0x0008; }  //!< @todo documentation
-static constexpr std::size_t UBX_ESF_MEAS_V0_FLAGS_NUMMEAS_GET(const uint16_t flags)                { return (flags >> 11) & 0x1f; }  //!< @todo documentation
-static constexpr uint32_t    UBX_ESF_MEAS_V0_DATA_DATAFIELD_GET(const uint32_t data)                { return data & 0x00ffffff; }  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_MEAS_V0_DATA_DATATYPE_GET(const uint32_t data)                 { return (data >> 24) & 0x0000003f; } //!< same enum as UBX-ESF-STATUS.type it seems
+static constexpr std::size_t UBX_ESF_MEAS_V0_FLAGS_NUMMEAS(const uint16_t flags)                    { return (flags >> 11) & 0x1f; }  //!< @todo documentation
+static constexpr uint32_t    UBX_ESF_MEAS_V0_DATA_DATAFIELD(const uint32_t data)                    { return data & 0x00ffffff; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_MEAS_V0_DATA_DATATYPE(const uint32_t data)                     { return (data >> 24) & 0x0000003f; } //!< same enum as UBX-ESF-STATUS.type it seems
 static constexpr double      UBX_ESF_MEAS_V0_CALIBTTAG_SCALE                                        = 1e-3;  //!< @todo documentation
 static constexpr std::size_t UBX_ESF_MEAS_V0_SIZE(const uint8_t* msg)                               { return /* argh.. nice message design! */ \
-    sizeof(UBX_ESF_MEAS_V0_GROUP0) + UBX_FRAME_SIZE + (UBX_ESF_MEAS_V0_FLAGS_NUMMEAS_GET(*((uint16_t *)&((uint8_t *)(msg))[UBX_HEAD_SIZE + 4])) * sizeof(UBX_ESF_MEAS_V0_GROUP1)) +
+    sizeof(UBX_ESF_MEAS_V0_GROUP0) + UBX_FRAME_SIZE + (UBX_ESF_MEAS_V0_FLAGS_NUMMEAS(*((uint16_t *)&((uint8_t *)(msg))[UBX_HEAD_SIZE + 4])) * sizeof(UBX_ESF_MEAS_V0_GROUP1)) +
     (UBX_ESF_MEAS_V0_FLAGS_CALIBTTAGVALID(*((uint16_t *)&((uint8_t *)(msg))[UBX_HEAD_SIZE + 4])) ? sizeof(UBX_ESF_MEAS_V0_GROUP2) : 0); }  //!< @todo documentation
 // clang-format on
 
@@ -1068,21 +1070,21 @@ static constexpr std::size_t UBX_ESF_STATUS_V2_MIN_SIZE                         
 static constexpr std::size_t UBX_ESF_STATUS_V2_SIZE(const uint8_t* msg)                             { return  //!< @todo documentation
     sizeof(UBX_ESF_STATUS_V2_GROUP0) + UBX_FRAME_SIZE + (((uint8_t *)(msg))[UBX_HEAD_SIZE + 15] * sizeof(UBX_ESF_STATUS_V2_GROUP1)); }  //!< @todo documentation
 static constexpr double      UBX_ESF_STATUS_V2_ITOW_SCALE                                           = 1e-3;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_WTINITSTATUS_GET(const uint8_t initStatus1) { return initStatus1 & 0x03; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_WTINITSTATUS(const uint8_t initStatus1)  { return initStatus1 & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_WTINITSTATUS_OFF                         = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_WTINITSTATUS_INITALIZING                 = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_WTINITSTATUS_INITIALIZED                 = 2;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_MNTALGSTATUS_GET(const uint8_t initStatus1) { return (initStatus1 >> 2) & 0x07; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_MNTALGSTATUS(const uint8_t initStatus1)  { return (initStatus1 >> 2) & 0x07; }  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_MNTALGSTATUS_OFF                         = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_MNTALGSTATUS_INITALIZING                 = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_MNTALGSTATUS_INITIALIZED1                = 2;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_MNTALGSTATUS_INITIALIZED2                = 3;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_INSINITSTATUS_GET(const uint8_t initStatus1){ return (initStatus1 >> 5) & 0x07; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_INSINITSTATUS(const uint8_t initStatus1) { return (initStatus1 >> 5) & 0x07; }  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_INSINITSTATUS_OFF                        = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_INSINITSTATUS_INITALIZING                = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_INSINITSTATUS_INITIALIZED1               = 2;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS1_INSINITSTATUS_INITIALIZED2               = 3;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS2_IMUINITSTATUS_GET(const uint8_t initStatus2){ return initStatus2 & 0x03; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS2_IMUINITSTATUS(const uint8_t initStatus2) { return initStatus2 & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS2_IMUINITSTATUS_OFF                        = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS2_IMUINITSTATUS_INITALIZING                = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_INITSTATUS2_IMUINITSTATUS_INITIALIZED1               = 2;  //!< @todo documentation
@@ -1091,15 +1093,15 @@ static constexpr uint8_t     UBX_ESF_STATUS_V2_FUSIONMODE_INIT                  
 static constexpr uint8_t     UBX_ESF_STATUS_V2_FUSIONMODE_FUSION                                    = 0x01;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_FUSIONMODE_SUSPENDED                                 = 0x02;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_FUSIONMODE_DISABLED                                  = 0x03;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS1_TYPE_GET(const uint8_t sensStatus1)      { return sensStatus1 & 0x3f; } //!< same enum as UBX-ESF-MEAS.dataType it seems  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS1_TYPE(const uint8_t sensStatus1)          { return sensStatus1 & 0x3f; } //!< same enum as UBX-ESF-MEAS.dataType it seems  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS1_USED                                     = 0x40;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS1_READY                                    = 0x80;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_CALIBSTATUS_GET(const uint8_t sensStatus2)  { return sensStatus2 & 0x03; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_CALIBSTATUS(const uint8_t sensStatus2)   { return sensStatus2 & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_CALIBSTATUS_NOTCALIB                     = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_CALIBSTATUS_CALIBRATING                  = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_CALIBSTATUS_CALIBRATED1                  = 2;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_CALIBSTATUS_CALIBRATED2                  = 3;  //!< @todo documentation
-static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_TIMESTATUS_GET(const uint8_t sensStatus2)   { return (sensStatus2 >> 2) & 0x03; }  //!< @todo documentation
+static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_TIMESTATUS(const uint8_t sensStatus2)    { return (sensStatus2 >> 2) & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_TIMESTATUS_NODATA                        = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_TIMESTATUS_FIRSTBYTE                     = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_ESF_STATUS_V2_SENSSTATUS2_TIMESTATUS_EVENT                         = 2;  //!< @todo documentation
@@ -1161,7 +1163,7 @@ static constexpr std::size_t UBX_MON_COMMS_V0_SIZE(const uint8_t* msg)          
     sizeof(UBX_MON_COMMS_V0_GROUP0) + UBX_FRAME_SIZE + (((uint8_t *)(msg))[UBX_HEAD_SIZE + 1] * sizeof(UBX_MON_COMMS_V0_GROUP1)); }  //!< @todo documentation
 static constexpr bool        UBX_MON_COMMS_V0_TXERRORS_MEM(const uint8_t txErrors)                  { return (txErrors & 0x01) == 0x01; }  //!< @todo documentation
 static constexpr bool        UBX_MON_COMMS_V0_TXERRORS_ALLOC(const uint8_t txErrors)                { return (txErrors & 0x02) == 0x02; }  //!< @todo documentation
-static constexpr uint8_t     UBX_MON_COMMS_V0_TXERRORS_OUTPUTPORT_GET(const uint8_t txErrors)       { return (txErrors >> 3) & 0x7; }  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_COMMS_V0_TXERRORS_OUTPUTPORT(const uint8_t txErrors)           { return (txErrors >> 3) & 0x7; }  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_COMMS_V0_TXERRORS_OUTPUTPORT_NA                                = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_COMMS_V0_TXERRORS_OUTPUTPORT_I2C                               = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_COMMS_V0_TXERRORS_OUTPUTPORT_UART1                             = 2;  //!< @todo documentation
@@ -1212,7 +1214,7 @@ static_assert(sizeof(UBX_MON_HW_V0_GROUP0) == 60, "");
 static constexpr std::size_t UBX_MON_HW_V0_SIZE                                                     = sizeof(UBX_MON_HW_V0_GROUP0) + UBX_FRAME_SIZE;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_HW_V0_FLAGS_RTCCALIB                                           = 0x01;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_HW_V0_FLAGS_SAFEBOOT                                           = 0x02;  //!< @todo documentation
-static constexpr uint8_t     UBX_MON_HW_V0_FLAGS_JAMMINGSTATE_GET(const uint8_t flags)              { return (flags >> 2) & 0x03; }  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_HW_V0_FLAGS_JAMMINGSTATE(const uint8_t flags)                  { return (flags >> 2) & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_HW_V0_FLAGS_JAMMINGSTATE_UNKNOWN                               = 0x00;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_HW_V0_FLAGS_JAMMINGSTATE_OK                                    = 0x01;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_HW_V0_FLAGS_JAMMINGSTATE_WARNING                               = 0x02;  //!< @todo documentation
@@ -1256,7 +1258,7 @@ struct UBX_MON_HW2_V0_GROUP0  // clang-format off
 static_assert(sizeof(UBX_MON_HW2_V0_GROUP0) == 28, "");
 
 // clang-format off
-static constexpr std::size_t UBX_MON_HW2_V0_SIZE                                                    = sizeof(UBX_MON_HW2_V0_GROUP0);   //!< @todo documentation+ UBX_FRAME_SIZE
+static constexpr std::size_t UBX_MON_HW2_V0_SIZE                                                    = sizeof(UBX_MON_HW2_V0_GROUP0) + UBX_FRAME_SIZE;   //!< @todo documentation+ UBX_FRAME_SIZE
 static constexpr uint8_t     UBX_MON_HW2_V0_CFGSOURCE_ROM                                           = 114;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_HW2_V0_CFGSOURCE_OTP                                           = 111;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_HW2_V0_CFGSOURCE_PIN                                           = 112;  //!< @todo documentation
@@ -1369,7 +1371,7 @@ static constexpr uint8_t     UBX_MON_RF_V0_VERSION                              
 static constexpr std::size_t UBX_MON_RF_V0_MIN_SIZE                                                 = sizeof(UBX_MON_RF_V0_GROUP0) + UBX_FRAME_SIZE;  //!< @todo documentation
 static constexpr std::size_t UBX_MON_RF_V0_SIZE(const uint8_t* msg)                                 { return
     sizeof(UBX_MON_RF_V0_GROUP0) + UBX_FRAME_SIZE + (((uint8_t *)(msg))[UBX_HEAD_SIZE + 1] * sizeof(UBX_MON_RF_V0_GROUP1)); }  //!< @todo documentation
-static constexpr uint8_t     UBX_MON_RF_V0_FLAGS_JAMMINGSTATE(const uint8_t f)                      { return f & 0x03; }  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_RF_V0_FLAGS_JAMMINGSTATE(const uint8_t flags)                  { return flags & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_RF_V0_FLAGS_JAMMINGSTATE_UNKN                                  = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_RF_V0_FLAGS_JAMMINGSTATE_OK                                    = 1;  //!< @todo documentation
 static constexpr uint8_t     UBX_MON_RF_V0_FLAGS_JAMMINGSTATE_WARN                                  = 2;  //!< @todo documentation
@@ -1405,10 +1407,12 @@ struct UBX_MON_SPAN_V0_GROUP0  // clang-format off
 
 static_assert(sizeof(UBX_MON_SPAN_V0_GROUP0) == 4, "");
 
+static constexpr std::size_t UBX_MON_SPAN_V0_NUM_BINS = 255;  //!< Number of bins
+
 //! UBX-MON-RF (version 0, output) payload repeated group
 struct UBX_MON_SPAN_V0_GROUP1  // clang-format off
 {
-    uint8_t  spectrum[256];  //!< @todo documentation
+    uint8_t  spectrum[UBX_MON_SPAN_V0_NUM_BINS];  //!< @todo documentation
     uint32_t span;           //!< @todo documentation
     uint32_t res;            //!< @todo documentation
     uint32_t center;         //!< @todo documentation
@@ -1426,6 +1430,50 @@ static constexpr std::size_t UBX_MON_SPAN_V0_SIZE(const uint8_t* msg)           
     sizeof(UBX_MON_SPAN_V0_GROUP0) + UBX_FRAME_SIZE + (((uint8_t *)(msg))[UBX_HEAD_SIZE + 1] * sizeof(UBX_MON_SPAN_V0_GROUP1)); }  //!< @todo documentation
 static constexpr double      UBX_MON_SPAN_BIN_CENT_FREQ(const uint32_t center, const uint32_t span, const int ix)  { return
     (double)center + ((double)span * (((double)(ix) - 128.0) / 256.0)); }  //!< @todo documentation
+// clang-format on
+
+// ---------------------------------------------------------------------------------------------------------------------
+/**
+ * @name UBX-MON-SYS message
+ * @{
+ */
+
+//! UBX-MON-SYS (version 1, output) payload
+struct UBX_MON_SYS_V1_GROUP0  // clang-format off
+{
+    uint8_t  msgVer;       //!< @todo documentation
+    uint8_t  bootType;     //!< @todo documentation
+    uint8_t  cpuLoad;      //!< @todo documentation
+    uint8_t  cpuLoadMax;   //!< @todo documentation
+    uint8_t  memUsage;     //!< @todo documentation
+    uint8_t  memUsageMax;  //!< @todo documentation
+    uint8_t  ioUsage;      //!< @todo documentation
+    uint8_t  ioUsageMax;   //!< @todo documentation
+    uint32_t runTime;      //!< @todo documentation
+    uint16_t noticeCount;  //!< @todo documentation
+    uint16_t warnCount;    //!< @todo documentation
+    uint16_t errorCount;   //!< @todo documentation
+    int8_t   tempValue;    //!< @todo documentation
+    uint8_t  reserved[5];  //!< @todo documentation
+};  // clang-format on
+
+static_assert(sizeof(UBX_MON_SYS_V1_GROUP0) == 24, "");
+
+// clang-format off
+static constexpr uint8_t     UBX_MON_SYS_VERSION(const uint8_t* msg)                                { return msg[UBX_HEAD_SIZE]; }  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_VERSION                                                 = 0x01;  //!< @todo documentation
+static constexpr std::size_t UBX_MON_SYS_V1_SIZE                                                    = sizeof(UBX_MON_SYS_V1_GROUP0) + UBX_FRAME_SIZE;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_UNKNOWN                                        =  0;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_COLDSTART                                      =  1;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_WATCHDOG                                       =  2;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_HWRESET                                        =  3;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_HWBACKUP                                       =  4;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_SWBACKUP                                       =  5;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_SWRESET                                        =  6;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_VIOFAIL                                        =  7;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_VDDXFAIL                                       =  8;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_VDDRFFAIL                                      =  9;  //!< @todo documentation
+static constexpr uint8_t     UBX_MON_SYS_V1_BOOTTYPE_VCOREHIGHFAIL                                  = 10;  //!< @todo documentation
 // clang-format on
 
 ///@}
@@ -2067,8 +2115,8 @@ static constexpr bool        UBX_NAV_STATUS_V0_FLAGS_GPSFIXOK(const uint8_t flag
 static constexpr bool        UBX_NAV_STATUS_V0_FLAGS_DIFFSOLN(const uint8_t flags)                  { return (flags & 0x02) == 0x02; }  //!< @todo documentation
 static constexpr bool        UBX_NAV_STATUS_V0_FLAGS_WKNSET(const uint8_t flags)                    { return (flags & 0x04) == 0x04; }  //!< @todo documentation
 static constexpr bool        UBX_NAV_STATUS_V0_FLAGS_TOWSET(const uint8_t flags)                    { return (flags & 0x08) == 0x08; }  //!< @todo documentation
-static constexpr uint8_t     UBX_NAV_STATUS_V0_FIXSTAT_DIFFCORR                                     = 0x01;  //!< @todo documentation
-static constexpr uint8_t     UBX_NAV_STATUS_V0_FIXSTAT_CARRSOLNVALID                                = 0x02;  //!< @todo documentation
+static constexpr bool        UBX_NAV_STATUS_V0_FIXSTAT_DIFFCORR(const uint8_t fixStat)              { return (fixStat & 0x01) ==  0x01; } //!< @todo documentation
+static constexpr bool        UBX_NAV_STATUS_V0_FIXSTAT_CARRSOLNVALID(const uint8_t fixStat)         { return (fixStat & 0x02) ==  0x02; } //!< @todo documentation
 static constexpr uint8_t     UBX_NAV_STATUS_V0_FLAGS2_CARRSOLN(const uint8_t flags2)                { return (flags2 >> 6) & 0x03; }  //!< @todo documentation
 static constexpr uint8_t     UBX_NAV_STATUS_V0_FLAGS2_CARRSOLN_NO                                   = 0;  //!< @todo documentation
 static constexpr uint8_t     UBX_NAV_STATUS_V0_FLAGS2_CARRSOLN_FLOAT                                = 1;  //!< @todo documentation
@@ -2378,6 +2426,7 @@ static constexpr bool        UBX_RXM_RAWX_V1_TRKSTAT_PRVALID(const uint8_t trkSt
 static constexpr bool        UBX_RXM_RAWX_V1_TRKSTAT_CPVALID(const uint8_t trkStat)                 { return (trkStat & 0x02) == 0x02; }  //!< @todo documentation
 static constexpr bool        UBX_RXM_RAWX_V1_TRKSTAT_HALFCYC(const uint8_t trkStat)                 { return (trkStat & 0x04) == 0x04; }  //!< @todo documentation
 static constexpr bool        UBX_RXM_RAWX_V1_TRKSTAT_SUBHALFCYC(const uint8_t trkStat)              { return (trkStat & 0x08) == 0x08; }  //!< @todo documentation
+static constexpr int         UBX_RXM_RAWX_V1_GROUP1_FREQID_TO_SLOT(const uint8_t freqId)            { return (int)freqId - 7; }
 static constexpr std::size_t UBX_RXM_RAWX_V1_SIZE(const uint8_t *msg)                               { return
     ((sizeof(UBX_RXM_RAWX_V1_GROUP0) + UBX_FRAME_SIZE + (((uint8_t *)(msg))[UBX_HEAD_SIZE + 11] * sizeof(UBX_RXM_RAWX_V1_GROUP1)))); }  //!< @todo documentation
 
@@ -2447,6 +2496,7 @@ static_assert(sizeof(UBX_RXM_SFRBX_V2_GROUP1) == 4, "");
 static constexpr uint8_t     UBX_RXM_SFRBX_VERSION(const uint8_t* msg)                              { return msg[UBX_HEAD_SIZE + 6]; }  //!< @todo documentation
 static constexpr uint8_t     UBX_RXM_SFRBX_V2_VERSION                                               = 0x02;  //!< @todo documentation
 static constexpr std::size_t UBX_RXM_SFRBX_V2_MIN_SIZE                                              = sizeof(UBX_RXM_SFRBX_V2_GROUP0) + UBX_FRAME_SIZE;  //!< @todo documentation
+static constexpr int         UBX_RXM_SFRBX_V2_GROUP0_FREQID_TO_SLOT(const uint8_t freqId)           { return (int)freqId - 7; }
 // clang-format on
 
 ///@}

--- a/fpsdk_common/include/fpsdk_common/path.hpp
+++ b/fpsdk_common/include/fpsdk_common/path.hpp
@@ -140,6 +140,7 @@ class OutputFile
      * @returns true on success, false otherwise
      */
     bool Write(const std::vector<uint8_t>& data);
+
     /**
      * @brief Write data to file
      *
@@ -155,11 +156,127 @@ class OutputFile
      *
      * @returns the file path if the file has been opened before, the empty string otherwise
      */
-    const std::string& GetPath() const;
+    const std::string& Path() const;
+
+    /**
+     * @brief Check if output file is open
+     *
+     * @returns true if the file is open, false otherwise
+     */
+    bool IsOpen() const;
+
+    /**
+     * @brief Get file size
+     *
+     * @returns the size written to the file so far
+     */
+    std::size_t Size() const;
+
+    /**
+     * @brief Get error
+     *
+     * @returns an error string in case of error (e.g. after Write() failed), the empty string if there's no error
+     */
+    const std::string& Error() const;
 
    private:
     std::string path_;                  //!< File path
     std::unique_ptr<std::ostream> fh_;  //!< File handle
+    std::size_t size_ = 0;              //!< Size written
+    std::string error_;                 //!< Last error
+};
+
+/**
+ * @brief Input file handle
+ */
+class InputFile
+{
+   public:
+    InputFile();
+    ~InputFile();
+
+    /**
+     * @brief Open input file for reading
+     *
+     * @param[in]  path  The path / filename, can end in ".gz" for compressed output
+     *
+     * @returns true on success, failure otherwise
+     */
+    bool Open(const std::string& path);
+
+    /**
+     * @brief Close input file
+     */
+    void Close();
+
+    /**
+     * @brief Read data from file
+     *
+     * @param[out]  data  Buffer to read into
+     * @param[in]   size  Size of buffer (> 0)
+     *
+     * @returns the size read, 0 if at end of file
+     */
+    std::size_t Read(uint8_t* data, const std::size_t size);
+
+    /**
+     * @brief Get file path
+     *
+     * @returns the file path if the file has been opened before, the empty string otherwise
+     */
+    const std::string& Path() const;
+
+    /**
+     * @brief Check if output file is open
+     *
+     * @returns true if the file is open, false otherwise
+     */
+    bool IsOpen() const;
+
+    /**
+     * @brief Get file size
+     *
+     * @returns the file size
+     */
+    std::size_t Size() const;
+
+    /**
+     * @brief Get file position
+     *
+     * @returns the current file position
+     */
+    std::size_t Tell() const;
+
+    /**
+     * @brief Seek to position
+     *
+     * @param[in]  pos  Position to seek to
+     *
+     * @returns true on success, false otherwise (our of range, cannot seek)
+     */
+    bool Seek(const std::size_t pos);
+
+    /**
+     * @brief Check if handle can seek
+     *
+     * @returns true if Seek() is possible, false if not (e.g. compressed file)
+     */
+    bool CanSeek() const;
+
+    /**
+     * @brief Get error
+     *
+     * @returns an error string in case of error (e.g. after Open() failed), the empty string if there's no error
+     */
+    const std::string& Error() const;
+
+   private:
+    std::string path_;                  //!< File path
+    std::unique_ptr<std::istream> fh_;  //!< File handle
+    std::size_t size_ = 0;              //!< File size
+    std::size_t pos_ = 0;               //!< File position
+    std::string error_;                 //!< Last error
+    bool can_seek_ = false;             //!< Seek possible?
 };
 
 /**

--- a/fpsdk_common/src/codegen.pl
+++ b/fpsdk_common/src/codegen.pl
@@ -231,6 +231,7 @@ my @UBX_MESSAGES =
     { class => 'NAV',    name => 'SBAS',           msgid => 0x32 },
     { class => 'NAV',    name => 'SIG',            msgid => 0x43 },
     { class => 'NAV',    name => 'SLAS',           msgid => 0x42 },
+    { class => 'NAV',    name => 'SOL',            msgid => 0x01 },
     { class => 'NAV',    name => 'STATUS',         msgid => 0x03 },
     { class => 'NAV',    name => 'SVIN',           msgid => 0x3b },
     { class => 'NAV',    name => 'TIMEBDS',        msgid => 0x24 },

--- a/fpsdk_common/src/fpl.cpp
+++ b/fpsdk_common/src/fpl.cpp
@@ -474,15 +474,15 @@ LogStatus::LogStatus(const FplMessage& log_msg)
                     pos_lat_ = status["pos_lat"].as<double>();
                     pos_lon_ = status["pos_lon"].as<double>();
                     pos_height_ = status["pos_height"].as<double>();
-                    using GnssFixType = fpsdk::common::gnss::GnssFixType;
+                    using FixType = fpsdk::common::gnss::FixType;
                     const bool pos_avail =
-                        ((pos_source_ > POS_SOURCE_UNKNOWN) && ((GnssFixType)pos_fix_type_ > GnssFixType::NOFIX));
+                        ((pos_source_ > POS_SOURCE_UNKNOWN) && ((FixType)pos_fix_type_ > FixType::NOFIX));
                     const char* pos_source_str =
                         (pos_source_ == POS_SOURCE_GNSS ? "GNSS" : (pos_source_ == POS_SOURCE_FUSION ? "FUSION" : "?"));
                     info_ += " log_time=" + log_time_iso_ +
                              fpsdk::common::string::Sprintf(" pos=%s/%s/%.6f/%.6f/%.0f", pos_source_str,
-                                 fpsdk::common::gnss::GnssFixTypeStr((GnssFixType)pos_fix_type_),
-                                 pos_avail ? pos_lat_ : NAN, pos_avail ? pos_lon_ : NAN, pos_avail ? pos_height_ : NAN);
+                                 fpsdk::common::gnss::FixTypeStr((FixType)pos_fix_type_), pos_avail ? pos_lat_ : NAN,
+                                 pos_avail ? pos_lon_ : NAN, pos_avail ? pos_height_ : NAN);
                 }
                 if (status_ver >= 3) {
                     queue_bsize_ = status["queue_bsize"].as<uint32_t>();

--- a/fpsdk_common/src/gnss.cpp
+++ b/fpsdk_common/src/gnss.cpp
@@ -28,20 +28,20 @@ namespace common {
 namespace gnss {
 /* ****************************************************************************************************************** */
 
-const char* GnssFixTypeStr(const GnssFixType fix_type)
+const char* FixTypeStr(const FixType fix_type)
 {
     switch (fix_type) {  // clang-format off
-        case GnssFixType::UNKNOWN:         return "UNKNOWN";
-        case GnssFixType::NOFIX:           return "NOFIX";
-        case GnssFixType::DRONLY:          return "DRONLY";
-        case GnssFixType::TIME:            return "TIME";
-        case GnssFixType::SPP_2D:          return "SPP_2D";
-        case GnssFixType::SPP_3D:          return "SPP_3D";
-        case GnssFixType::SPP_3D_DR:       return "SPP_3D_DR";
-        case GnssFixType::RTK_FLOAT:       return "RTK_FLOAT";
-        case GnssFixType::RTK_FIXED:       return "RTK_FIXED";
-        case GnssFixType::RTK_FLOAT_DR:    return "RTK_FLOAT_DR";
-        case GnssFixType::RTK_FIXED_DR:    return "RTK_FIXED_DR";
+        case FixType::UNKNOWN:         return "UNKNOWN";
+        case FixType::NOFIX:           return "NOFIX";
+        case FixType::DRONLY:          return "DRONLY";
+        case FixType::TIME:            return "TIME";
+        case FixType::SPP_2D:          return "SPP_2D";
+        case FixType::SPP_3D:          return "SPP_3D";
+        case FixType::SPP_3D_DR:       return "SPP_3D_DR";
+        case FixType::RTK_FLOAT:       return "RTK_FLOAT";
+        case FixType::RTK_FIXED:       return "RTK_FIXED";
+        case FixType::RTK_FLOAT_DR:    return "RTK_FLOAT_DR";
+        case FixType::RTK_FIXED_DR:    return "RTK_FIXED_DR";
     }  // clang-format on
     return "?";
 }
@@ -64,31 +64,47 @@ const char* GnssStr(const Gnss gnss)
     return "?";
 }
 
+char GnssChar(const Gnss gnss)
+{
+    switch (gnss) {  // clang-format off
+        case Gnss::UNKNOWN:   return '?';
+        case Gnss::GPS:       return 'G';
+        case Gnss::SBAS:      return 'S';
+        case Gnss::GAL:       return 'E';
+        case Gnss::BDS:       return 'C';
+        case Gnss::QZSS:      return 'J';
+        case Gnss::GLO:       return 'R';
+        case Gnss::NAVIC:     return 'I';
+    }  // clang-format on
+
+    return '?';
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 
 const char* SignalStr(const Signal signal, const bool kurz)
 {
     switch (signal) {  // clang-format off
         case Signal::UNKNOWN:    return kurz ? "UNKN"  : "UNKNOWN";
+        case Signal::GPS_L1CA:   return kurz ? "L1CA"  : "GPS_L1CA";
+        case Signal::GPS_L2C:    return kurz ? "L2C"   : "GPS_L2C";
+        case Signal::GPS_L5:     return kurz ? "L5"    : "GPS_L5";
+        case Signal::SBAS_L1CA:  return kurz ? "L1CA"  : "SBAS_L1CA";
+        case Signal::GAL_E1:     return kurz ? "E1"    : "GAL_E1";
+        case Signal::GAL_E5A:    return kurz ? "E5A"   : "GAL_E5A";
+        case Signal::GAL_E5B:    return kurz ? "E5B"   : "GAL_E5B";
+        case Signal::GAL_E6:     return kurz ? "E6"    : "GAL_E6";
         case Signal::BDS_B1C:    return kurz ? "B1C"   : "BDS_B1C";
         case Signal::BDS_B1I:    return kurz ? "B1I"   : "BDS_B1I";
         case Signal::BDS_B2A:    return kurz ? "B2A"   : "BDS_B2A";
         case Signal::BDS_B2I:    return kurz ? "B2I"   : "BDS_B2I";
         case Signal::BDS_B3I:    return kurz ? "B3I"   : "BDS_B3I";
-        case Signal::GAL_E1:     return kurz ? "E1"    : "GAL_E1";
-        case Signal::GAL_E5A:    return kurz ? "E5A"   : "GAL_E5A";
-        case Signal::GAL_E5B:    return kurz ? "E5B"   : "GAL_E5B";
-        case Signal::GAL_E6:     return kurz ? "E6"    : "GAL_E6";
-        case Signal::GLO_L1OF:   return kurz ? "L1OF"  : "GLO_L1OF";
-        case Signal::GLO_L2OF:   return kurz ? "L2OF"  : "GLO_L2OF";
-        case Signal::GPS_L1CA:   return kurz ? "L1CA"  : "GPS_L1CA";
-        case Signal::GPS_L2C:    return kurz ? "L2C"   : "GPS_L2C";
-        case Signal::GPS_L5:     return kurz ? "L5"    : "GPS_L5";
         case Signal::QZSS_L1CA:  return kurz ? "L1CA"  : "QZSS_L1CA";
         case Signal::QZSS_L1S:   return kurz ? "L1S"   : "QZSS_L1S";
         case Signal::QZSS_L2C:   return kurz ? "L2C"   : "QZSS_L2C";
         case Signal::QZSS_L5:    return kurz ? "L5"    : "QZSS_L5";
-        case Signal::SBAS_L1CA:  return kurz ? "L1CA"  : "SBAS_L1CA";
+        case Signal::GLO_L1OF:   return kurz ? "L1OF"  : "GLO_L1OF";
+        case Signal::GLO_L2OF:   return kurz ? "L2OF"  : "GLO_L2OF";
         case Signal::NAVIC_L5A:  return kurz ? "L5A"   : "NAVIC_L5A";
     }  // clang-format on
 
@@ -102,8 +118,8 @@ const char* BandStr(const Band band)
     switch (band) {  // clang-format off
         case Band::UNKNOWN: return "UNKNOWN";
         case Band::L1:      return "L1";
-        case Band::L2:      return "L2";
         case Band::E6:      return "E6";
+        case Band::L2:      return "L2";
         case Band::L5:      return "L5";
     }  // clang-format on
 
@@ -112,41 +128,157 @@ const char* BandStr(const Band band)
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+const char* SigUseStr(const SigUse use)
+{
+    switch (use) {  // clang-format off
+        case SigUse::UNKNOWN:   return "UNKNOWN";
+        case SigUse::NONE:      return "NONE";
+        case SigUse::SEARCH:    return "SEARCH";
+        case SigUse::ACQUIRED:  return "ACQUIRED";
+        case SigUse::UNUSABLE:  return "UNUSABLE";
+        case SigUse::CODELOCK:  return "CODELOCK";
+        case SigUse::CARRLOCK:  return "CARRLOCK";
+        }  // clang-format on
+    return "?";
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+const char* SigCorrStr(const SigCorr corr)
+{
+    switch (corr) {  // clang-format off
+        case SigCorr::UNKNOWN:    return "UNKNOWN";
+        case SigCorr::NONE:       return "NONE";
+        case SigCorr::SBAS:       return "SBAS";
+        case SigCorr::BDS:        return "BDS";
+        case SigCorr::RTCM2:      return "RTCM2";
+        case SigCorr::RTCM3_OSR:  return "RTCM3_OSR";
+        case SigCorr::RTCM3_SSR:  return "RTCM3_SSR";
+        case SigCorr::QZSS_SLAS:  return "QZSS_SLAS";
+        case SigCorr::SPARTN:     return "SPARTN";
+        }  // clang-format on
+    return "?";
+}
+// ---------------------------------------------------------------------------------------------------------------------
+
+const char* SigIonoStr(const SigIono iono)
+{
+    switch (iono) {  // clang-format off
+        case SigIono::UNKNOWN:    return "UNKNOWN";
+        case SigIono::NONE:       return "NONE";
+        case SigIono::KLOB_GPS:   return "KLOB_GPS";
+        case SigIono::KLOB_BDS:   return "KLOB_BDS";
+        case SigIono::SBAS:       return "SBAS";
+        case SigIono::DUAL_FREQ:  return "DUAL_FREQ";
+        }  // clang-format on
+    return "?";
+}
+// ---------------------------------------------------------------------------------------------------------------------
+
+const char* SigHealthStr(const SigHealth health)
+{
+    switch (health) {  // clang-format off
+        case SigHealth::UNKNOWN:    return "UNKNOWN";
+        case SigHealth::HEALTHY:    return "HEALTHY";
+        case SigHealth::UNHEALTHY:  return "UNHEALTHY";
+    }  // clang-format on
+    return "?";
+}
+// ---------------------------------------------------------------------------------------------------------------------
+
+const char* SatOrbStr(const SatOrb orb)
+{
+    switch (orb) {  // clang-format off
+        case SatOrb::UNKNOWN:  return "UNKNOWN";
+        case SatOrb::NONE:     return "NONE";
+        case SatOrb::EPH:      return "EPH";
+        case SatOrb::ALM:      return "ALM";
+        case SatOrb::PRED:     return "PRED";
+        case SatOrb::OTHER:    return "OTHER";
+    }  // clang-format on
+    return "?";
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
 Band SignalToBand(const Signal signal)
 {
     switch (signal) {  // clang-format off
-        case Signal::GPS_L1CA:   /* FALLTHROUGH */
-        case Signal::BDS_B1I:    /* FALLTHROUGH */
-        case Signal::BDS_B1C:    /* FALLTHROUGH */
+        // L1 (E1)
+        case Signal::GPS_L1CA:
+        case Signal::SBAS_L1CA:  /* FALLTHROUGH */
         case Signal::GAL_E1:     /* FALLTHROUGH */
-        case Signal::GLO_L1OF:   /* FALLTHROUGH */
+        case Signal::BDS_B1C:    /* FALLTHROUGH */
+        case Signal::BDS_B1I:    /* FALLTHROUGH */
         case Signal::QZSS_L1CA:  /* FALLTHROUGH */
         case Signal::QZSS_L1S:   /* FALLTHROUGH */
-        case Signal::SBAS_L1CA:  return Band::L1;
-        case Signal::GPS_L2C:    /* FALLTHROUGH */
-        case Signal::BDS_B2I:    /* FALLTHROUGH */
-        case Signal::GAL_E5B:    /* FALLTHROUGH */
-        case Signal::GLO_L2OF:   /* FALLTHROUGH */
-        case Signal::QZSS_L2C:   return Band::L2;
+        case Signal::GLO_L1OF:   return Band::L1;
+        // E6
         case Signal::BDS_B3I:    /* FALLTHROUGH */
         case Signal::GAL_E6:     return Band::E6;
-        case Signal::BDS_B2A:    /* FALLTHROUGH */
+        // L2
+        case Signal::GPS_L2C:    /* FALLTHROUGH */
+        case Signal::GAL_E5B:    /* FALLTHROUGH */
+        case Signal::BDS_B2I:    /* FALLTHROUGH */
+        case Signal::QZSS_L2C:   /* FALLTHROUGH */
+        case Signal::GLO_L2OF:   return Band::L2;
+        // L5 (E5)
         case Signal::GPS_L5:     /* FALLTHROUGH */
-        case Signal::QZSS_L5:    /* FALLTHROUGH */
         case Signal::GAL_E5A:    /* FALLTHROUGH */
+        case Signal::BDS_B2A:    /* FALLTHROUGH */
+        case Signal::QZSS_L5:    /* FALLTHROUGH */
         case Signal::NAVIC_L5A:  return Band::L5;
-        case Signal::UNKNOWN:    return Band::UNKNOWN;
+        case Signal::UNKNOWN:    break;
     }  // clang-format on
-
     return Band::UNKNOWN;
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-const char* SatStr(const Sat sat)
+Gnss SignalToGnss(const Signal signal)
 {
-    const Gnss gnss = SatToGnss(sat);
-    const SvNr svnr = SatToSvNr(sat);
+    switch (signal) {  // clang-format off
+        case Signal::GPS_L1CA:   /* FALLTHROUGH */
+        case Signal::GPS_L2C:    /* FALLTHROUGH */
+        case Signal::GPS_L5:     return Gnss::GPS;
+        case Signal::SBAS_L1CA:  return Gnss::SBAS;
+        case Signal::GAL_E1:     /* FALLTHROUGH */
+        case Signal::GAL_E5A:    /* FALLTHROUGH */
+        case Signal::GAL_E5B:    /* FALLTHROUGH */
+        case Signal::GAL_E6:     return Gnss::GAL;
+        case Signal::BDS_B1C:    /* FALLTHROUGH */
+        case Signal::BDS_B1I:    /* FALLTHROUGH */
+        case Signal::BDS_B2A:    /* FALLTHROUGH */
+        case Signal::BDS_B2I:    /* FALLTHROUGH */
+        case Signal::BDS_B3I:    return Gnss::BDS;
+        case Signal::QZSS_L1CA:  /* FALLTHROUGH */
+        case Signal::QZSS_L1S:   /* FALLTHROUGH */
+        case Signal::QZSS_L2C:   /* FALLTHROUGH */
+        case Signal::QZSS_L5:    return Gnss::QZSS;
+        case Signal::GLO_L1OF:   /* FALLTHROUGH */
+        case Signal::GLO_L2OF:   return Gnss::GLO;
+        case Signal::NAVIC_L5A:  return Gnss::NAVIC;
+        case Signal::UNKNOWN:    break;
+    }  // clang-format on
+    return Gnss::UNKNOWN;
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+static_assert(sizeof(Sat) == sizeof(uint16_t), "");
+static_assert(sizeof(SatSig) == sizeof(uint32_t), "");
+static_assert(types::EnumToVal(Gnss::UNKNOWN) == 0, "");
+static_assert(types::EnumToVal(Band::UNKNOWN) == 0, "");
+static_assert(types::EnumToVal(Signal::UNKNOWN) == 0, "");
+static_assert(INVALID_SAT.id_ == 0x0000, "");
+static_assert(INVALID_SATSIG.id_ == 0x00000000, "");
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+const char* Sat::GetStr() const
+{
+    const Gnss gnss = GetGnss();
+    const SvNr svnr = GetSvNr();
 
     switch (gnss) {
         case Gnss::GPS: {
@@ -251,23 +383,20 @@ const char* SatStr(const Sat sat)
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-Sat StrSat(const char* str)
+Sat::Sat(const char* str)
 {
-    Sat sat = INVALID_SAT;
     char c = '\0';
     uint8_t n = 0;
     int len = 0;
-    if ((std::sscanf(str, "%c%" SCNu8 "%n", &c, &n, &len) == 2) && (len == 3)) {
-        // clang-format off
-        if      (((uint8_t)c == types::EnumToVal(Gnss::GPS))   && (n >= FIRST_GPS)   && (n < (FIRST_GPS   + NUM_GPS)))   { sat = GnssSvNrToSat(Gnss::GPS,   n); }
-        else if (((uint8_t)c == types::EnumToVal(Gnss::SBAS))  && (n >= FIRST_SBAS)  && (n < (FIRST_SBAS  + NUM_SBAS)))  { sat = GnssSvNrToSat(Gnss::SBAS,  n); }
-        else if (((uint8_t)c == types::EnumToVal(Gnss::GAL))   && (n >= FIRST_GAL)   && (n < (FIRST_GAL   + NUM_GAL)))   { sat = GnssSvNrToSat(Gnss::GAL,   n); }
-        else if (((uint8_t)c == types::EnumToVal(Gnss::BDS))   && (n >= FIRST_BDS)   && (n < (FIRST_BDS   + NUM_BDS)))   { sat = GnssSvNrToSat(Gnss::BDS,   n); }
-        else if (((uint8_t)c == types::EnumToVal(Gnss::QZSS))  && (n >= FIRST_QZSS)  && (n < (FIRST_QZSS  + NUM_QZSS)))  { sat = GnssSvNrToSat(Gnss::QZSS,  n); }
-        else if (((uint8_t)c == types::EnumToVal(Gnss::GLO))   && (n >= FIRST_GLO)   && (n < (FIRST_GLO   + NUM_GLO)))   { sat = GnssSvNrToSat(Gnss::GLO,   n); }
-        else if (((uint8_t)c == types::EnumToVal(Gnss::NAVIC)) && (n >= FIRST_NAVIC) && (n < (FIRST_NAVIC + NUM_NAVIC))) { sat = GnssSvNrToSat(Gnss::NAVIC, n); }
-    }
-    return sat;
+    if ((std::sscanf(str, "%c%" SCNu8 "%n", &c, &n, &len) == 2) && (len == 3)) {  // clang-format off
+        if      ((c == 'G' /* Gnss::GPS   */) && (n >= FIRST_GPS)   && (n < (FIRST_GPS   + NUM_GPS)))   { *this = { Gnss::GPS,   (SvNr)n }; }
+        else if ((c == 'S' /* Gnss::SBAS  */) && (n >= FIRST_SBAS)  && (n < (FIRST_SBAS  + NUM_SBAS)))  { *this = { Gnss::SBAS,  (SvNr)n }; }
+        else if ((c == 'E' /* Gnss::GAL   */) && (n >= FIRST_GAL)   && (n < (FIRST_GAL   + NUM_GAL)))   { *this = { Gnss::GAL,   (SvNr)n }; }
+        else if ((c == 'C' /* Gnss::BDS   */) && (n >= FIRST_BDS)   && (n < (FIRST_BDS   + NUM_BDS)))   { *this = { Gnss::BDS,   (SvNr)n }; }
+        else if ((c == 'J' /* Gnss::QZSS  */) && (n >= FIRST_QZSS)  && (n < (FIRST_QZSS  + NUM_QZSS)))  { *this = { Gnss::QZSS,  (SvNr)n }; }
+        else if ((c == 'R' /* Gnss::GLO   */) && (n >= FIRST_GLO)   && (n < (FIRST_GLO   + NUM_GLO)))   { *this = { Gnss::GLO,   (SvNr)n }; }
+        else if ((c == 'I' /* Gnss::NAVIC */) && (n >= FIRST_NAVIC) && (n < (FIRST_NAVIC + NUM_NAVIC))) { *this = { Gnss::NAVIC, (SvNr)n }; }
+    }  // clang-format on
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -296,37 +425,37 @@ Sat UbxGnssIdSvIdToSat(const uint8_t gnssId, const uint8_t svId)
     switch (gnssId) {
         case UBX_GNSSID_GPS:
             if ((svId >= UBX_FIRST_GPS) && (svId < (UBX_FIRST_GPS + UBX_NUM_GPS))) {
-                return GnssSvNrToSat(Gnss::GPS, svId - UBX_FIRST_GPS + FIRST_GPS);
+                return { Gnss::GPS, (SvNr)(svId - UBX_FIRST_GPS + FIRST_GPS) };
             }
             break;
         case UBX_GNSSID_SBAS:
             if ((svId >= UBX_FIRST_SBAS) && (svId < (UBX_FIRST_SBAS + UBX_NUM_SBAS))) {
-                return GnssSvNrToSat(Gnss::SBAS, svId - UBX_FIRST_SBAS + FIRST_SBAS);
+                return { Gnss::SBAS, (SvNr)(svId - UBX_FIRST_SBAS + FIRST_SBAS) };
             }
             break;
         case UBX_GNSSID_GAL:
             if ((svId >= UBX_FIRST_GAL) && (svId < (UBX_FIRST_GAL + UBX_NUM_GAL))) {
-                return GnssSvNrToSat(Gnss::GAL, svId - UBX_FIRST_GAL + FIRST_GAL);
+                return { Gnss::GAL, (SvNr)(svId - UBX_FIRST_GAL + FIRST_GAL) };
             }
             break;
         case UBX_GNSSID_BDS:
             if ((svId >= UBX_FIRST_BDS) && (svId < (UBX_FIRST_BDS + UBX_NUM_BDS))) {
-                return GnssSvNrToSat(Gnss::BDS, svId - UBX_FIRST_BDS + FIRST_BDS);
+                return { Gnss::BDS, (SvNr)(svId - UBX_FIRST_BDS + FIRST_BDS) };
             }
             break;
         case UBX_GNSSID_QZSS:
             if ((svId >= UBX_FIRST_QZSS) && (svId < (UBX_FIRST_QZSS + UBX_NUM_QZSS))) {
-                return GnssSvNrToSat(Gnss::QZSS, svId - UBX_FIRST_QZSS + FIRST_QZSS);
+                return { Gnss::QZSS, (SvNr)(svId - UBX_FIRST_QZSS + FIRST_QZSS) };
             }
             break;
         case UBX_GNSSID_GLO:
             if ((svId >= UBX_FIRST_GLO) && (svId < (UBX_FIRST_GLO + UBX_NUM_GLO))) {
-                return GnssSvNrToSat(Gnss::GLO, svId - UBX_FIRST_GLO + FIRST_GLO);
+                return { Gnss::GLO, (SvNr)(svId - UBX_FIRST_GLO + FIRST_GLO) };
             }
             break;
         case UBX_GNSSID_NAVIC:
             if ((svId >= UBX_FIRST_NAVIC) && (svId < (UBX_FIRST_NAVIC + UBX_NUM_NAVIC))) {
-                return GnssSvNrToSat(Gnss::NAVIC, svId - UBX_FIRST_NAVIC + FIRST_NAVIC);
+                return { Gnss::NAVIC, (SvNr)(svId - UBX_FIRST_NAVIC + FIRST_NAVIC) };
             }
             break;
     }
@@ -403,6 +532,138 @@ Signal UbxGnssIdSigIdToSignal(const uint8_t gnssId, const uint8_t sigId)
             }
             break;
     }  // clang-format on
+    return Signal::UNKNOWN;
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+FixType NmeaQualityGgaToFixType(const parser::nmea::NmeaQualityGga quality)
+{
+    switch (quality) {  // clang-format off
+        case parser::nmea::NmeaQualityGga::NOFIX:       /* FALLTHROUGH */
+        case parser::nmea::NmeaQualityGga::MANUAL:      return FixType::NOFIX;
+        case parser::nmea::NmeaQualityGga::SPP:         /* FALLTHROUGH */
+        case parser::nmea::NmeaQualityGga::SIM:         /* FALLTHROUGH */
+        case parser::nmea::NmeaQualityGga::DGNSS:       return FixType::SPP_3D;
+        case parser::nmea::NmeaQualityGga::PPS:         return FixType::TIME;
+        case parser::nmea::NmeaQualityGga::RTK_FIXED:   return FixType::RTK_FIXED;
+        case parser::nmea::NmeaQualityGga::RTK_FLOAT:   return FixType::RTK_FLOAT;
+        case parser::nmea::NmeaQualityGga::ESTIMATED:   return FixType::DRONLY;
+        case parser::nmea::NmeaQualityGga::UNSPECIFIED: break;
+    }  // clang-format on
+    return FixType::UNKNOWN;
+}
+
+FixType NmeaModeRmcGnsToFixType(const parser::nmea::NmeaModeRmcGns mode)
+{
+    switch (mode) {  // clang-format off
+        case parser::nmea::NmeaModeRmcGns::INVALID:     /* FALLTHROUGH */
+        case parser::nmea::NmeaModeRmcGns::MANUAL:      return FixType::NOFIX;
+        case parser::nmea::NmeaModeRmcGns::AUTONOMOUS:  /* FALLTHROUGH */
+        case parser::nmea::NmeaModeRmcGns::DGNSS:       /* FALLTHROUGH */
+        case parser::nmea::NmeaModeRmcGns::PRECISE:     /* FALLTHROUGH */
+        case parser::nmea::NmeaModeRmcGns::SIM:         return FixType::SPP_3D;
+        case parser::nmea::NmeaModeRmcGns::ESTIMATED:   return FixType::DRONLY;
+        case parser::nmea::NmeaModeRmcGns::RTK_FIXED:   return FixType::RTK_FIXED;
+        case parser::nmea::NmeaModeRmcGns::RTK_FLOAT:   return FixType::RTK_FLOAT;
+        case parser::nmea::NmeaModeRmcGns::UNSPECIFIED: break;
+    }  // clang-format on
+    return FixType::UNKNOWN;
+}
+
+FixType NmeaModeGllVtgToFixType(const parser::nmea::NmeaModeGllVtg mode)
+{
+    switch (mode) {  // clang-format off
+        case parser::nmea::NmeaModeGllVtg::INVALID:     /* FALLTHROUGH */
+        case parser::nmea::NmeaModeGllVtg::MANUAL:      return FixType::NOFIX;
+        case parser::nmea::NmeaModeGllVtg::AUTONOMOUS:  /* FALLTHROUGH */
+        case parser::nmea::NmeaModeGllVtg::DGNSS:       /* FALLTHROUGH */
+        case parser::nmea::NmeaModeGllVtg::SIM:         return FixType::SPP_3D;
+        case parser::nmea::NmeaModeGllVtg::ESTIMATED:   return FixType::DRONLY;
+        case parser::nmea::NmeaModeGllVtg::UNSPECIFIED: break;
+    }  // clang-format on
+    return FixType::UNKNOWN;
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+Sat NmeaSystemIdSvIdToSat(
+    const parser::nmea::NmeaSystemId systemId, const uint8_t svId, const parser::nmea::NmeaVersion nmeaVersion)
+{
+    using namespace parser::nmea;
+
+    switch (systemId) {
+        case NmeaSystemId::GPS_SBAS:
+            if ((svId >= nmeaVersion.svid_min_gps) && (svId <= nmeaVersion.svid_max_gps)) {
+                return { Gnss::GPS, (SvNr)(svId - nmeaVersion.svid_min_gps + FIRST_GPS) };
+            }
+            if ((svId >= nmeaVersion.svid_min_sbas) && (svId <= nmeaVersion.svid_max_sbas)) {
+                return { Gnss::SBAS, (SvNr)(svId - nmeaVersion.svid_min_sbas + FIRST_SBAS) };
+            }
+            break;
+        case NmeaSystemId::GLO:
+            if ((svId >= nmeaVersion.svid_min_glo) && (svId <= nmeaVersion.svid_max_glo)) {
+                return { Gnss::GLO, (SvNr)(svId - nmeaVersion.svid_min_glo + FIRST_GLO) };
+            }
+            break;
+        case NmeaSystemId::GAL:
+            if ((svId >= nmeaVersion.svid_min_gal) && (svId <= nmeaVersion.svid_max_gal)) {
+                return { Gnss::GAL, (SvNr)(svId - nmeaVersion.svid_min_gal + FIRST_GAL) };
+            }
+            break;
+        case NmeaSystemId::BDS:
+            if ((svId >= nmeaVersion.svid_min_bds) && (svId <= nmeaVersion.svid_max_bds)) {
+                return { Gnss::BDS, (SvNr)(svId - nmeaVersion.svid_min_bds + FIRST_BDS) };
+            }
+            break;
+        case NmeaSystemId::QZSS:
+            if ((svId >= nmeaVersion.svid_min_qzss) && (svId <= nmeaVersion.svid_max_qzss)) {
+                return { Gnss::QZSS, (SvNr)(svId - nmeaVersion.svid_min_qzss + FIRST_QZSS) };
+            }
+            break;
+        case NmeaSystemId::NAVIC:
+            if ((svId >= nmeaVersion.svid_min_navic) && (svId <= nmeaVersion.svid_max_navic)) {
+                return { Gnss::NAVIC, (SvNr)(svId - nmeaVersion.svid_min_navic + FIRST_NAVIC) };
+            }
+            break;
+        case NmeaSystemId::UNSPECIFIED:
+            break;
+    }
+    return INVALID_SAT;
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+Signal NmeaSignalIdToSignal(const parser::nmea::NmeaSignalId signalId)
+{
+    using namespace parser::nmea;
+    switch (signalId) {  // clang-format off
+        case NmeaSignalId::GPS_L1CA:      return Signal::GPS_L1CA;
+        case NmeaSignalId::GPS_L2CL:      /* FALLTHROUGH */
+        case NmeaSignalId::GPS_L2CM:      return Signal::GPS_L2C;
+        case NmeaSignalId::GPS_L5I:       /* FALLTHROUGH */
+        case NmeaSignalId::GPS_L5Q:       return Signal::GPS_L5;
+        case NmeaSignalId::GLO_L1OF:      return Signal::GLO_L1OF;
+        case NmeaSignalId::GLO_L2OF:      return Signal::GLO_L2OF;
+        case NmeaSignalId::GAL_E1:        return Signal::GAL_E1;
+        case NmeaSignalId::GAL_E5A:       return Signal::GAL_E5A;
+        case NmeaSignalId::GAL_E5B:       return Signal::GAL_E5B;
+        case NmeaSignalId::GAL_E6BC:      /* FALLTHROUGH */
+        case NmeaSignalId::GAL_E6A:       return Signal::GAL_E6;
+        case NmeaSignalId::BDS_B1ID:      return Signal::BDS_B1I;
+        case NmeaSignalId::BDS_B2ID:      return Signal::BDS_B2I;
+        case NmeaSignalId::BDS_B1C:       return Signal::BDS_B1C;
+        case NmeaSignalId::BDS_B2A:       return Signal::BDS_B2A;
+        case NmeaSignalId::QZSS_L1CA:     return Signal::QZSS_L1CA;
+        case NmeaSignalId::QZSS_L1S:      return Signal::QZSS_L1S;
+        case NmeaSignalId::QZSS_L2CM:     /* FALLTHROUGH */
+        case NmeaSignalId::QZSS_L2CL:     return Signal::QZSS_L2C;
+        case NmeaSignalId::QZSS_L5I:      /* FALLTHROUGH */
+        case NmeaSignalId::QZSS_L5Q:      return Signal::QZSS_L5;
+        case NmeaSignalId::NAVIC_L5A:     return Signal::NAVIC_L5A;
+        case NmeaSignalId::UNSPECIFIED:   /* FALLTHROUGH */
+        case NmeaSignalId::NONE:          break;
+    } // clang-format off
     return Signal::UNKNOWN;
 }
 

--- a/fpsdk_common/src/logging.cpp
+++ b/fpsdk_common/src/logging.cpp
@@ -202,7 +202,7 @@ void LoggingDefaultWriteFn(const LoggingParams& params, const LoggingLevel level
         if (len >= sizeof(output)) {
             len = sizeof(output) - 10;
         }
-        len += std::snprintf(&output[len], sizeof(output) - len, "%s", suffix);
+        /* len += */ std::snprintf(&output[len], sizeof(output) - len, "%s", suffix);
     }
 
     // Put the entire output line at once (see comment above)

--- a/fpsdk_common/src/parser.cpp
+++ b/fpsdk_common/src/parser.cpp
@@ -264,8 +264,8 @@ void Parser::EmitMessage(ParserMsg& msg, const std::size_t size, const Protocol 
     msg.proto_ = proto;
     msg.info_.clear();
     char sname[MAX_NAME_SIZE];
-    const uint8_t* mdata = msg.data_.data();
-    const std::size_t msize = msg.data_.size();
+    const uint8_t* mdata = msg.Data();
+    const std::size_t msize = msg.Size();
     switch (proto) {  // clang-format off
         case Protocol::FP_A:  // Handled in case Protocol::NMEA below                                                   // GCOVR_EXCL_LINE
             break;                                                                                                      // GCOVR_EXCL_LINE
@@ -301,7 +301,7 @@ void Parser::EmitMessage(ParserMsg& msg, const std::size_t size, const Protocol 
 
     stats_.Update(msg);
     msg.seq_ = stats_.n_msgs_;
-    PARSER_TRACE("process: emit %s, size %d", msg.name_.c_str(), (int)msg.data_.size());
+    PARSER_TRACE("process: emit %s, size %d", msg.name_.c_str(), (int)msg.Size());
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -327,7 +327,7 @@ void Parser::EmitGarbage(ParserMsg& msg)
     stats_.Update(msg);
     msg.seq_ = stats_.n_msgs_;
 
-    PARSER_TRACE("process: emit %s, size %d ", msg.name_.c_str(), (int)msg.data_.size());
+    PARSER_TRACE("process: emit %s, size %d ", msg.name_.c_str(), (int)msg.Size());
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/fpsdk_common/src/parser/fpb.cpp
+++ b/fpsdk_common/src/parser/fpb.cpp
@@ -172,7 +172,7 @@ bool FpbGetMessageInfo(char* info, const std::size_t size, const uint8_t* msg, c
     std::size_t len = 0;
 
     // Common stringification
-    len += snprintf(&info[len], size - len, "%04" PRIx16 "@%" PRIu16, FpbMsgId(msg), FpbMsgTime(msg));
+    len += snprintf(&info[len], size - len, "%04" PRIx16 "@%05" PRIu16, FpbMsgId(msg), FpbMsgTime(msg));
 
     // Specific stringification for some messages
     switch (FpbMsgId(msg)) {

--- a/fpsdk_common/src/parser/types.cpp
+++ b/fpsdk_common/src/parser/types.cpp
@@ -108,7 +108,7 @@ void ParserMsg::MakeInfo() const
             constexpr int num = 16;
             sinfo[0] = '\0';
             for (int ix = 0; (ix < num) && (ix < msize); ix++) {
-                std::snprintf(&sinfo[ix * 3], sizeof(sinfo - (ix * 3)), "%02x ", mdata[ix]);
+                std::snprintf(&sinfo[ix * 3], sizeof(sinfo) - (ix * 3), "%02x ", mdata[ix]);
             }
             if (msize > 16) {
                 sinfo[(num * 3) + 0] = '.';
@@ -128,7 +128,7 @@ void ParserMsg::MakeInfo() const
 
 void ParserStats::Update(const ParserMsg& msg)
 {
-    const auto size = msg.data_.size();
+    const auto size = msg.Size();
     switch (msg.proto_) {
         case Protocol::FP_A:
             n_fpa_++;

--- a/fpsdk_common/src/zfstream.cpp
+++ b/fpsdk_common/src/zfstream.cpp
@@ -1,5 +1,6 @@
 #ifndef _DOXYGEN_
 // clang-format off
+// NOLINTBEGIN
 /*
  * A C++ I/O streams interface to the zlib gz* functions
  *
@@ -480,3 +481,4 @@ gzofstream::close()
     this->setstate(std::ios_base::failbit);
 }
 #endif // !_DOXYGEN_
+// NOLINTEND

--- a/fpsdk_common/test/gnss_test.cpp
+++ b/fpsdk_common/test/gnss_test.cpp
@@ -12,6 +12,9 @@
  */
 
 /* LIBC/STL */
+#include <map>
+#include <set>
+#include <unordered_map>
 
 /* EXTERNAL */
 #include <gtest/gtest.h>
@@ -24,21 +27,21 @@ namespace {
 /* ****************************************************************************************************************** */
 using namespace fpsdk::common::gnss;
 
-TEST(GnssTest, GnssFixTypeStr)
+TEST(GnssTest, FixTypeStr)
 {
     // clang-format off
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::UNKNOWN)),        std::string("UNKNOWN"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::NOFIX)),          std::string("NOFIX"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::DRONLY)),         std::string("DRONLY"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::TIME)),           std::string("TIME"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::SPP_2D)),         std::string("SPP_2D"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::SPP_3D)),         std::string("SPP_3D"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::SPP_3D_DR)),      std::string("SPP_3D_DR"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::RTK_FLOAT)),      std::string("RTK_FLOAT"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::RTK_FIXED)),      std::string("RTK_FIXED"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::RTK_FLOAT_DR)),   std::string("RTK_FLOAT_DR"));
-    EXPECT_EQ(std::string(GnssFixTypeStr(GnssFixType::RTK_FIXED_DR)),   std::string("RTK_FIXED_DR"));
-    EXPECT_EQ(std::string(GnssFixTypeStr((GnssFixType)99)),             std::string("?")); // NOLINT
+    EXPECT_EQ(std::string(FixTypeStr(FixType::UNKNOWN)),        std::string("UNKNOWN"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::NOFIX)),          std::string("NOFIX"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::DRONLY)),         std::string("DRONLY"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::TIME)),           std::string("TIME"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::SPP_2D)),         std::string("SPP_2D"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::SPP_3D)),         std::string("SPP_3D"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::SPP_3D_DR)),      std::string("SPP_3D_DR"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::RTK_FLOAT)),      std::string("RTK_FLOAT"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::RTK_FIXED)),      std::string("RTK_FIXED"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::RTK_FLOAT_DR)),   std::string("RTK_FLOAT_DR"));
+    EXPECT_EQ(std::string(FixTypeStr(FixType::RTK_FIXED_DR)),   std::string("RTK_FIXED_DR"));
+    EXPECT_EQ(std::string(FixTypeStr((FixType)99)),             std::string("?")); // NOLINT
     // clang-format on
 }
 
@@ -104,79 +107,141 @@ TEST(GnssTest, BandStr)
 
 TEST(GnssTest, Sat)
 {
-    const Sat sat = GnssSvNrToSat(Gnss::GPS, 12);
-    DEBUG("sat=%04x %02x %02x", sat, (int)SatToGnss(sat), (int)SatToSvNr(sat));
-    EXPECT_NE(sat, INVALID_SAT);
-    EXPECT_EQ(SatToGnss(sat), Gnss::GPS);
-    EXPECT_EQ(SatToSvNr(sat), 12);
+    {
+        const Sat sat(Gnss::GPS, 12);
+        EXPECT_NE(sat, INVALID_SAT);
+        EXPECT_EQ(sat.GetGnss(), Gnss::GPS);
+        EXPECT_EQ(sat.GetSvNr(), 12);
+    }
+    {
+        const Sat sat1(Gnss::GPS, 12);
+        const Sat sat2(Gnss::GAL, 12);
+        const Sat sat3(Gnss::GAL, 12);
+        EXPECT_LT(sat1, sat2);
+        EXPECT_NE(sat1, sat2);
+        EXPECT_EQ(sat2, sat3);
+    }
+    {
+        std::map<Sat, bool> map;
+        map.emplace(Sat(Gnss::GAL, 12), true);
+        map.emplace(Sat(Gnss::GPS, 12), true);
+        EXPECT_EQ(map.begin()->first, Sat(Gnss::GPS, 12));
+    }
+    {
+        std::unordered_map<Sat, bool> umap;
+        umap.emplace(Sat(Gnss::GAL, 12), true);
+        umap.emplace(Sat(Gnss::GPS, 12), true);
+        EXPECT_EQ(umap.size(), 2);
+    }
+    {
+        std::set<Sat> set;
+        set.emplace(Sat(Gnss::GAL, 12));
+        set.emplace(Sat(Gnss::GPS, 12));
+        EXPECT_EQ(set.size(), 2);
+    }
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
 
 TEST(GnssTest, SatSig)
 {
-    const SatSig satsig = GnssSvNrBandSignalToSatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L1CA);
-    DEBUG("satsig=%08x %02x  %02x  %02x %02x", satsig, (int)SatSigToGnss(satsig), (int)SatSigToSvNr(satsig),
-        (int)SatSigToBand(satsig), (int)SatSigToSignal(satsig));
-    EXPECT_NE(satsig, INVALID_SATSIG);
-    EXPECT_EQ(SatSigToGnss(satsig), Gnss::GPS);
-    EXPECT_EQ(SatSigToSvNr(satsig), 12);
-    EXPECT_EQ(SatSigToBand(satsig), Band::L1);
-    EXPECT_EQ(SatSigToSignal(satsig), Signal::GPS_L1CA);
+    {
+        const SatSig satsig(Gnss::GPS, 12, Band::L1, Signal::GPS_L1CA);
+        EXPECT_NE(satsig, INVALID_SATSIG);
+        EXPECT_EQ(satsig.GetGnss(), Gnss::GPS);
+        EXPECT_EQ(satsig.GetSvNr(), 12);
+        EXPECT_EQ(satsig.GetBand(), Band::L1);
+        EXPECT_EQ(satsig.GetSignal(), Signal::GPS_L1CA);
+    }
+    {
+        const SatSig satsig(Sat(Gnss::GPS, 12), Signal::GPS_L1CA);
+        EXPECT_NE(satsig, INVALID_SATSIG);
+        EXPECT_EQ(satsig.GetGnss(), Gnss::GPS);
+        EXPECT_EQ(satsig.GetSvNr(), 12);
+        EXPECT_EQ(satsig.GetBand(), Band::L1);
+        EXPECT_EQ(satsig.GetSignal(), Signal::GPS_L1CA);
+    }
+    {
+        EXPECT_EQ(INVALID_SATSIG.GetSat(), INVALID_SAT);
+    }
+    {
+        std::map<SatSig, bool> map;
+        map.emplace(SatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L2C), true);
+        map.emplace(SatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L1CA), true);
+        EXPECT_EQ(map.begin()->first, SatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L1CA));
+    }
+    {
+        std::unordered_map<SatSig, bool> umap;
+        umap.emplace(SatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L2C), true);
+        umap.emplace(SatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L1CA), true);
+        EXPECT_EQ(umap.size(), 2);
+    }
+    {
+        std::set<SatSig> set;
+        set.emplace(SatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L2C));
+        set.emplace(SatSig(Gnss::GPS, 12, Band::L1, Signal::GPS_L1CA));
+        EXPECT_EQ(set.size(), 2);
+    }
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
 
 TEST(GnssTest, SatStr)
-{
+{  // clang-format off
+
     // Valid
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::GPS, 1))), std::string("G01"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::SBAS, 22))), std::string("S22"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::GAL, 12))), std::string("E12"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::BDS, 5))), std::string("C05"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::QZSS, 9))), std::string("J09"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::GLO, 15))), std::string("R15"));
+    EXPECT_EQ(std::string(Sat(Gnss::GPS,     1).GetStr()), std::string("G01"));
+    EXPECT_EQ(std::string(Sat(Gnss::SBAS,   22).GetStr()), std::string("S22"));
+    EXPECT_EQ(std::string(Sat(Gnss::GAL,    12).GetStr()), std::string("E12"));
+    EXPECT_EQ(std::string(Sat(Gnss::BDS,     5).GetStr()), std::string("C05"));
+    EXPECT_EQ(std::string(Sat(Gnss::QZSS,    9).GetStr()), std::string("J09"));
+    EXPECT_EQ(std::string(Sat(Gnss::GLO,    15).GetStr()), std::string("R15"));
 
     // Invalid
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::GPS, 0))), std::string("G??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::GPS, 33))), std::string("G??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::SBAS, 19))), std::string("S??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::SBAS, 59))), std::string("S??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::GAL, 37))), std::string("E??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::BDS, 64))), std::string("C??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::QZSS, 11))), std::string("J??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::GLO, 33))), std::string("R??"));
-    EXPECT_EQ(std::string(SatStr(GnssSvNrToSat(Gnss::UNKNOWN, 12))), std::string("???"));
+    EXPECT_EQ(std::string(Sat(Gnss::GPS,     0).GetStr()), std::string("G??"));
+    EXPECT_EQ(std::string(Sat(Gnss::GPS,    33).GetStr()), std::string("G??"));
+    EXPECT_EQ(std::string(Sat(Gnss::SBAS,   19).GetStr()), std::string("S??"));
+    EXPECT_EQ(std::string(Sat(Gnss::SBAS,   59).GetStr()), std::string("S??"));
+    EXPECT_EQ(std::string(Sat(Gnss::GAL,    37).GetStr()), std::string("E??"));
+    EXPECT_EQ(std::string(Sat(Gnss::BDS,    64).GetStr()), std::string("C??"));
+    EXPECT_EQ(std::string(Sat(Gnss::QZSS,   11).GetStr()), std::string("J??"));
+    EXPECT_EQ(std::string(Sat(Gnss::GLO,    33).GetStr()), std::string("R??"));
+    EXPECT_EQ(std::string(Sat(Gnss::UNKNOWN, 2).GetStr()), std::string("???"));
+
+    // clang-format on
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
 
 TEST(GnssTest, StrSat)
-{
+{  // clang-format off
+
     // Valid
-    EXPECT_EQ(StrSat("G01"), GnssSvNrToSat(Gnss::GPS, 1));
-    EXPECT_EQ(StrSat("S22"), GnssSvNrToSat(Gnss::SBAS, 22));
-    EXPECT_EQ(StrSat("E12"), GnssSvNrToSat(Gnss::GAL, 12));
-    EXPECT_EQ(StrSat("C05"), GnssSvNrToSat(Gnss::BDS, 5));
-    EXPECT_EQ(StrSat("J09"), GnssSvNrToSat(Gnss::QZSS, 9));
-    EXPECT_EQ(StrSat("R15"), GnssSvNrToSat(Gnss::GLO, 15));
+    EXPECT_EQ(Sat("G01"), Sat(Gnss::GPS,   1));
+    EXPECT_EQ(Sat("S22"), Sat(Gnss::SBAS, 22));
+    EXPECT_EQ(Sat("E12"), Sat(Gnss::GAL,  12));
+    EXPECT_EQ(Sat("C05"), Sat(Gnss::BDS,   5));
+    EXPECT_EQ(Sat("J09"), Sat(Gnss::QZSS,  9));
+    EXPECT_EQ(Sat("R15"), Sat(Gnss::GLO,  15));
 
     // Invalid
-    EXPECT_EQ(StrSat("G00"), INVALID_SAT);
-    EXPECT_EQ(StrSat("G33"), INVALID_SAT);
-    EXPECT_EQ(StrSat("S19"), INVALID_SAT);
-    EXPECT_EQ(StrSat("S59"), INVALID_SAT);
-    EXPECT_EQ(StrSat("E37"), INVALID_SAT);
-    EXPECT_EQ(StrSat("C64"), INVALID_SAT);
-    EXPECT_EQ(StrSat("J11"), INVALID_SAT);
-    EXPECT_EQ(StrSat("R33"), INVALID_SAT);
-    EXPECT_EQ(StrSat("gugugs"), INVALID_SAT);
-    EXPECT_EQ(StrSat(""), INVALID_SAT);
-    EXPECT_EQ(StrSat("G1"), INVALID_SAT);
-    EXPECT_EQ(StrSat("E1"), INVALID_SAT);
-    EXPECT_EQ(StrSat("C1"), INVALID_SAT);
-    EXPECT_EQ(StrSat("J1"), INVALID_SAT);
-    EXPECT_EQ(StrSat("R1"), INVALID_SAT);
+    EXPECT_EQ(Sat("G00"),    INVALID_SAT);
+    EXPECT_EQ(Sat("G33"),    INVALID_SAT);
+    EXPECT_EQ(Sat("S19"),    INVALID_SAT);
+    EXPECT_EQ(Sat("S59"),    INVALID_SAT);
+    EXPECT_EQ(Sat("E37"),    INVALID_SAT);
+    EXPECT_EQ(Sat("C64"),    INVALID_SAT);
+    EXPECT_EQ(Sat("J11"),    INVALID_SAT);
+    EXPECT_EQ(Sat("R33"),    INVALID_SAT);
+    EXPECT_EQ(Sat("gugugs"), INVALID_SAT);
+    EXPECT_EQ(Sat(""),       INVALID_SAT);
+    EXPECT_EQ(Sat("G1"),     INVALID_SAT);
+    EXPECT_EQ(Sat("E1"),     INVALID_SAT);
+    EXPECT_EQ(Sat("C1"),     INVALID_SAT);
+    EXPECT_EQ(Sat("J1"),     INVALID_SAT);
+    EXPECT_EQ(Sat("R1"),     INVALID_SAT);
+
+    // clang-format on
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -191,8 +256,9 @@ TEST(GnssTest, UbxGnssIdToGnss)
 
 TEST(GnssTest, UbxGnssIdSvIdToSat)
 {
-    EXPECT_EQ(UbxGnssIdSvIdToSat(0, 12), GnssSvNrToSat(Gnss::GPS, 12));
-    EXPECT_EQ(UbxGnssIdSvIdToSat(2, 1), GnssSvNrToSat(Gnss::GAL, 1));
+    EXPECT_EQ(UbxGnssIdSvIdToSat(0, 12), Sat(Gnss::GPS, 12));
+    EXPECT_EQ(UbxGnssIdSvIdToSat(2, 1), Sat(Gnss::GAL, 1));
+    EXPECT_EQ(UbxGnssIdSvIdToSat(1, 123), Sat(Gnss::SBAS, 23));
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/fpsdk_common/test/parser_fpa_test.cpp
+++ b/fpsdk_common/test/parser_fpa_test.cpp
@@ -12,6 +12,7 @@
  */
 
 /* LIBC/STL */
+#include <cstring>
 #include <string>
 
 /* EXTERNAL */
@@ -32,7 +33,7 @@ TEST(ParserFpaTest, FpaGetMessageMeta)
         //                     TTTTTTTT V PPPPPPPPPPP
         const char* msg = "$FP,ODOMETRY,1,...,...,...*xx\r\n";
         FpaMessageMeta meta;
-        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.msg_type_), std::string("ODOMETRY")) << msg;
         EXPECT_EQ(meta.msg_version_, 1) << msg;
         EXPECT_EQ(meta.payload_ix0_, 15) << msg;
@@ -43,7 +44,7 @@ TEST(ParserFpaTest, FpaGetMessageMeta)
         //                     TTTTTTTT V
         const char* msg = "$FP,ODOMETRY,1*xx\r\n";
         FpaMessageMeta meta;
-        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.msg_type_), std::string("ODOMETRY")) << msg;
         EXPECT_EQ(meta.msg_version_, 1) << msg;
         EXPECT_EQ(meta.payload_ix0_, 0) << msg;
@@ -54,7 +55,7 @@ TEST(ParserFpaTest, FpaGetMessageMeta)
         //                     TTTTTTTT
         const char* msg = "$FP,ODOMETRY*xx\r\n";
         FpaMessageMeta meta;
-        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.msg_type_), std::string("ODOMETRY")) << msg;
         EXPECT_LT(meta.msg_version_, 0) << msg;
         EXPECT_EQ(meta.payload_ix0_, 0) << msg;
@@ -65,7 +66,7 @@ TEST(ParserFpaTest, FpaGetMessageMeta)
         //                     TTTTTTTT
         const char* msg = "$FP,ODOMETRY,*xx\r\n";
         FpaMessageMeta meta;
-        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.msg_type_), std::string("ODOMETRY")) << msg;
         EXPECT_LT(meta.msg_version_, 0) << msg;
         EXPECT_EQ(meta.payload_ix0_, 0) << msg;
@@ -76,7 +77,7 @@ TEST(ParserFpaTest, FpaGetMessageMeta)
         //                     TTTTTTTT
         const char* msg = "$FP,ODOMETRY,notanumber*xx\r\n";
         FpaMessageMeta meta;
-        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.msg_type_), std::string("ODOMETRY")) << msg;
         EXPECT_LT(meta.msg_version_, 0) << msg;
         EXPECT_EQ(meta.payload_ix0_, 13) << msg;
@@ -94,12 +95,12 @@ TEST(ParserFpaTest, FpaGetMessageMeta)
     {
         const char* msg = "$ABCDEFGHIJKLMNOP";
         FpaMessageMeta meta;
-        EXPECT_FALSE(FpaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg)));
+        EXPECT_FALSE(FpaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg)));
     }
     {
         const char* msg = "$GNABCDEFGHIJKLMNOPQRSTUVW,123,456,789*xx\r\n";
         FpaMessageMeta meta;
-        EXPECT_FALSE(FpaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_FALSE(FpaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.msg_type_), std::string("")) << msg;
         EXPECT_EQ(meta.msg_version_, 0) << msg;
         EXPECT_EQ(meta.payload_ix0_, 0) << msg;
@@ -114,19 +115,19 @@ TEST(ParserFpaTest, FpaGetMessageName)
     {
         const char* msg = "$FP,ODOMETRY,1,...,...,...*xx\r\n";
         char name[100];
-        EXPECT_TRUE(FpaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("FP_A-ODOMETRY")) << msg;
     }
     {
         const char* msg = "$FP,ODOMETRY,1*xx\r\n";
         char name[100];
-        EXPECT_TRUE(FpaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("FP_A-ODOMETRY")) << msg;
     }
     {
         const char* msg = "$FP,ODOMETRY,X*xx\r\n";  // Bad msg_version
         char name[100];
-        EXPECT_TRUE(FpaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(FpaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("FP_A-ODOMETRY")) << msg;
     }
     // Bad input
@@ -188,8 +189,9 @@ TEST(ParserFpaTest, FpaEoePayload)
     {
         FpaEoePayload payload;
         const char* msg = "$FP,EOE,1,2322,309663.800000,FUSION*62\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::EOE);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2322);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -199,8 +201,9 @@ TEST(ParserFpaTest, FpaEoePayload)
     {
         FpaEoePayload payload;
         const char* msg = "$FP,EOE,1,,,GNSS1*7C\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::EOE);
         EXPECT_FALSE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 0);
         EXPECT_FALSE(payload.gps_time.tow.valid);
@@ -210,8 +213,9 @@ TEST(ParserFpaTest, FpaEoePayload)
     {
         FpaEoePayload payload;
         const char* msg = "$FP,EOE,1,,,CHABIS*XX\r\n";
-        EXPECT_FALSE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_FALSE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_FALSE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::EOE);
         EXPECT_FALSE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 0);
         EXPECT_FALSE(payload.gps_time.tow.valid);
@@ -227,8 +231,9 @@ TEST(ParserFpaTest, FpaGnssantPayload)
     {
         FpaGnssantPayload payload;
         const char* msg = "$FP,GNSSANT,1,2234,305129.200151,short,off,0,open,on,28*65\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::GNSSANT);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2234);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -245,8 +250,9 @@ TEST(ParserFpaTest, FpaGnssantPayload)
     {
         FpaGnssantPayload payload;
         const char* msg = "$FP,GNSSANT,1,,,,,,,,*XX\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::GNSSANT);
         EXPECT_FALSE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 0);
         EXPECT_FALSE(payload.gps_time.tow.valid);
@@ -270,8 +276,9 @@ TEST(ParserFpaTest, FpaGnsscorrPayload)
         FpaGnsscorrPayload payload;
         const char* msg =  // clang-format off
             "$FP,GNSSCORR,1,2237,250035.999865,8,25,18,8,25,18,0.2,1.0,0.8,5.3,2,47.366986804,8.532965023,481.1094,7254*3F\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::GNSSCORR);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2237);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -306,13 +313,13 @@ TEST(ParserFpaTest, FpaGnsscorrPayload)
     {
         FpaGnsscorrPayload payload;
         const char* msg = "$FP,GNSSCORR,1,2237,250548.999744,8,25,18,8,25,18,,,,,,,,,*24\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
         EXPECT_TRUE(payload.gps_time.week.valid);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::GNSSCORR);
         EXPECT_EQ(payload.gps_time.week.value, 2237);
         EXPECT_TRUE(payload.gps_time.tow.valid);
         EXPECT_NEAR(payload.gps_time.tow.value, 250548.999744, 1e-9);
-
         EXPECT_EQ(payload.gnss1_fix, FpaGnssFix::RTK_FIXED);
         EXPECT_TRUE(payload.gnss1_nsig_l1.valid);
         EXPECT_EQ(payload.gnss1_nsig_l1.value, 25);
@@ -351,8 +358,9 @@ TEST(ParserFpaTest, FpaRawimuPayload)
         FpaRawimuPayload payload;
         const char* msg =  // clang-format off
             "$FP,RAWIMU,1,2197,126191.777855,-0.199914,0.472851,9.917973,0.023436,0.007723,0.002131*34\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::RAWIMU);
         EXPECT_EQ(payload.which, FpaImuPayload::Which::RAWIMU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2197);
@@ -373,8 +381,9 @@ TEST(ParserFpaTest, FpaRawimuPayload)
         FpaRawimuPayload payload;
         const char* msg =  // clang-format off
             "$FP,RAWIMU,1,,,,,,,,*XX\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::RAWIMU);
         EXPECT_EQ(payload.which, FpaImuPayload::Which::RAWIMU);
         EXPECT_FALSE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 0);
@@ -396,8 +405,9 @@ TEST(ParserFpaTest, FpaRawimuPayload)
         FpaRawimuPayload payload;
         const char* msg =  // clang-format off
             "$FP,RAWIMU,2,2368,228734.073983,-0.118514,-0.082600,9.894035,0.014381,0.004794,-0.003196,0,1,*1C\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::RAWIMU);
         EXPECT_EQ(payload.which, FpaImuPayload::Which::RAWIMU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2368);
@@ -425,8 +435,9 @@ TEST(ParserFpaTest, FpaCorrimuPayload)
         FpaCorrimuPayload payload;
         const char* msg =  // clang-format off
             "$FP,CORRIMU,1,2197,126191.777855,-0.195224,0.393969,9.869998,0.013342,-0.004620,-0.000728*7D\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::CORRIMU);
         EXPECT_EQ(payload.which, FpaImuPayload::Which::CORRIMU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2197);
@@ -445,8 +456,9 @@ TEST(ParserFpaTest, FpaCorrimuPayload)
         FpaCorrimuPayload payload;
         const char* msg =  // clang-format off
             "$FP,CORRIMU,1,,,,,,,,*XX\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::CORRIMU);
         EXPECT_EQ(payload.which, FpaImuPayload::Which::CORRIMU);
         EXPECT_FALSE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 0);
@@ -466,8 +478,9 @@ TEST(ParserFpaTest, FpaCorrimuPayload)
         FpaCorrimuPayload payload;
         const char* msg =  // clang-format off
             "$FP,CORRIMU,2,2368,228734.073983,-0.102908,-0.096532,9.732782,0.002208,0.001499,-0.001206,1,1,*54\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::CORRIMU);
         EXPECT_EQ(payload.which, FpaImuPayload::Which::CORRIMU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2368);
@@ -494,8 +507,9 @@ TEST(ParserFpaTest, FpaImubiasPayload)
         FpaImubiasPayload payload;
         const char* msg =  // clang-format off
             "$FP,IMUBIAS,1,2342,321247.000000,2,1,1,3,0.008914,0.019806,0.150631,0.027202,0.010599,0.011393,0.00001,0.00001,0.00001,0.00001,0.00001,0.00001*4C\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::IMUBIAS);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2342);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -524,8 +538,9 @@ TEST(ParserFpaTest, FpaImubiasPayload)
     {
         FpaImubiasPayload payload;
         const char* msg = "$FP,IMUBIAS,1,2342,323844.000000,,,,,,,,,,,,,,,,*4C\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::IMUBIAS);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2342);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -561,8 +576,9 @@ TEST(ParserFpaTest, FpaLlhPayload)
         FpaLlhPayload payload;
         const char* msg =  // clang-format off
             "$FP,LLH,1,2231,227563.250000,47.392357470,8.448121451,473.5857,0.04533,0.03363,0.02884,0.00417,0.00086,-0.00136*62\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::LLH);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2231);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -582,8 +598,9 @@ TEST(ParserFpaTest, FpaLlhPayload)
     {
         FpaLlhPayload payload;
         const char* msg = "$FP,LLH,1,2231,227563.250000,,,,,,,,,*XX\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::LLH);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2231);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -613,8 +630,9 @@ TEST(ParserFpaTest, FpaOdometryPayload)
             "-17.1078,-0.0526,-0.3252,0.02245,0.00275,0.10369,-1.0385,-1.3707,9.8249,4,1,8,8,1,"
             "0.01761,0.02274,0.01713,-0.00818,0.00235,0.00129,0.00013,0.00015,0.00014,-0.00001,0.00001,0.00002,"
             "0.03482,0.06244,0.05480,0.00096,0.00509,0.00054,fp_release_vr2_2.54.0_160*4F\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::ODOMETRY);
         EXPECT_EQ(payload.which, FpaOdomPayload::Which::ODOMETRY);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2231);
@@ -682,8 +700,9 @@ TEST(ParserFpaTest, FpaOdomenuPayload)
             "-1.6994,-0.0222,0.20063,0.08621,-1.21972,-3.6947,-3.3827,9.7482,4,1,8,8,1,0.00415,0.00946,0.00746,"
             "-0.00149,-0.00084,0.00025,0.00003,0.00003,0.00012,0.00000,0.00000,0.00000,0.01742,0.01146,0.01612,"
             "-0.00550,-0.00007,-0.00050*74\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::ODOMENU);
         EXPECT_EQ(payload.which, FpaOdomPayload::Which::ODOMENU);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2180);
@@ -704,8 +723,9 @@ TEST(ParserFpaTest, FpaOdomshPayload)
             "-1.6994,-0.0222,0.20063,0.08621,-1.21972,-3.6947,-3.3827,9.7482,4,1,8,8,1,0.00415,0.00946,0.00746,"
             "-0.00149,-0.00084,0.00025,0.00003,0.00003,0.00012,0.00000,0.00000,0.00000,0.01742,0.01146,0.01612,"
             "-0.00550,-0.00007,-0.00050*74\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::ODOMSH);
         EXPECT_EQ(payload.which, FpaOdomPayload::Which::ODOMSH);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2180);
@@ -723,7 +743,8 @@ TEST(ParserFpaTest, FpaOdomstatusPayload)
         FpaOdomstatusPayload payload;
         const char* msg =  // clang-format off
             "$FP,ODOMSTATUS,1,2342,321241.350000,2,2,1,1,1,1,,0,,,,,,1,1,3,8,8,3,5,5,,0,6,,,,,,,,,,,,*24\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::ODOMSTATUS);
         EXPECT_TRUE(payload.valid_);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2342);
@@ -753,8 +774,9 @@ TEST(ParserFpaTest, FpaOdomstatusPayload)
     {
         FpaOdomstatusPayload payload;
         const char* msg = "$FP,ODOMSTATUS,1,2342,324917.700000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,*1E\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::ODOMSTATUS);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, 2342);
         EXPECT_TRUE(payload.gps_time.tow.valid);
@@ -789,16 +811,18 @@ TEST(ParserFpaTest, FpaTextPayload)
     {
         FpaTextPayload payload;
         const char* msg = "$FP,TEXT,1,INFO,Fixposition AG - www.fixposition.com*09\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::TEXT);
         EXPECT_EQ(payload.level, FpaTextLevel::INFO);
         EXPECT_EQ(std::string(payload.text), "Fixposition AG - www.fixposition.com");
     }
     {
         FpaTextPayload payload;
         const char* msg = "$FP,TEXT,1,NOPE,blabla*09\r\n";
-        EXPECT_FALSE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_FALSE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_FALSE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::TEXT);
         EXPECT_EQ(payload.level, FpaTextLevel::UNSPECIFIED);
         EXPECT_EQ(payload.text[0], '\0');
     }
@@ -812,8 +836,9 @@ TEST(ParserFpaTest, FpaTfPayload)
         FpaTfPayload payload;
         const char* msg =  // clang-format off
             "$FP,TF,2,2233,315835.000000,VRTK,CAM,-0.00000,-0.00000,-0.00000,1.000000,0.000000,0.000000,0.000000*6B\r\n";  // clang-format on
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, strlen(msg)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg, std::strlen(msg)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::TF);
         EXPECT_EQ(payload.gps_time.week.value, 2233);
         EXPECT_TRUE(payload.gps_time.tow.valid);
         EXPECT_NEAR(payload.gps_time.tow.value, 315835.000000, 1e-9);
@@ -838,8 +863,9 @@ TEST(ParserFpaTest, FpaTpPayload)
     {
         FpaTpPayload payload;
         const char* msg_v1 = "$FP,TP,1,GNSS1,UTC,USNO,195391,0.000000000000,18*4F\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg_v1, strlen(msg_v1)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg_v1, std::strlen(msg_v1)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::TP);
         EXPECT_EQ(std::string(payload.tp_name), "GNSS1");
         EXPECT_EQ(payload.timebase, FpaTimebase::UTC);
         EXPECT_EQ(payload.timeref, FpaTimeref::UTC_USNO);
@@ -856,8 +882,9 @@ TEST(ParserFpaTest, FpaTpPayload)
     {
         FpaTpPayload payload;
         const char* msg_v2 = "$FP,TP,2,GNSS1,UTC,NONE,124512,0.000000000000,18,2349*66\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg_v2, strlen(msg_v2)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg_v2, std::strlen(msg_v2)));
         EXPECT_TRUE(payload.valid_);
+        EXPECT_EQ(payload.msg_type_, FpaMessageType::TP);
         EXPECT_EQ(std::string(payload.tp_name), "GNSS1");
         EXPECT_EQ(payload.timebase, FpaTimebase::UTC);
         EXPECT_EQ(payload.timeref, FpaTimeref::UTC_NONE);
@@ -894,7 +921,7 @@ TEST(ParserFpaTest, FpaTimestamps)
 
     for (auto& t : tests) {
         FpaLlhPayload payload;
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)t.msg, strlen(t.msg))) << t.msg;
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)t.msg, std::strlen(t.msg))) << t.msg;
         EXPECT_TRUE(payload.valid_);
         EXPECT_TRUE(payload.gps_time.week.valid);
         EXPECT_EQ(payload.gps_time.week.value, t.wno);
@@ -910,13 +937,27 @@ TEST(ParserFpaTest, FpaVersionPayload)
     {
         FpaVersionPayload payload;
         const char* msg_v1 = "$FP,VERSION,1,fp_vrtk2-release-vr2_2.123.0-456,NAV_VR2,v1.3b,fp-5d6f64,VRTK2_STK,*3F\r\n";
-        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg_v1, strlen(msg_v1)));
+        EXPECT_TRUE(payload.SetFromMsg((const uint8_t*)msg_v1, std::strlen(msg_v1)));
         EXPECT_TRUE(payload.valid_);
         EXPECT_EQ(std::string(payload.sw_version), "fp_vrtk2-release-vr2_2.123.0-456");
         EXPECT_EQ(std::string(payload.hw_name), "NAV_VR2");
         EXPECT_EQ(std::string(payload.hw_ver), "v1.3b");
         EXPECT_EQ(std::string(payload.hw_uid), "fp-5d6f64");
         EXPECT_EQ(std::string(payload.product_model), "VRTK2_STK");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+TEST(ParserNmeaTest, FpaDecodeMessage)
+{
+    {
+        const char* msg = "$FP,VERSION,1,fp_vrtk2-release-vr2_2.123.0-456,NAV_VR2,v1.3b,fp-5d6f64,VRTK2_STK,*3F\r\n";
+        const FpaPayloadPtr payload = FpaDecodeMessage((const uint8_t*)msg, std::strlen(msg));
+        EXPECT_TRUE(payload);
+        EXPECT_EQ(payload->msg_type_, FpaMessageType::VERSION);
+        const auto version = dynamic_cast<const FpaVersionPayload&>(*payload);
+        EXPECT_EQ(std::string(version.product_model), "VRTK2_STK");
     }
 }
 

--- a/fpsdk_common/test/parser_fpb_test.cpp
+++ b/fpsdk_common/test/parser_fpb_test.cpp
@@ -117,7 +117,7 @@ TEST(ParserFpbTest, FpbMakeMessage)
         parser.Add(msg);
         ParserMsg parser_msg;
         EXPECT_TRUE(parser.Process(parser_msg));
-        EXPECT_EQ(parser_msg.data_.size(), FP_B_FRAME_SIZE + payload.size());
+        EXPECT_EQ(parser_msg.Size(), FP_B_FRAME_SIZE + payload.size());
         EXPECT_EQ(std::string(parser_msg.name_), std::string("FP_B-UNITTEST2"));
         // Payload should be the same
         EXPECT_TRUE(std::memcmp(payload.data(), &parser_msg.data_[FP_B_HEAD_SIZE], payload.size()) == 0);

--- a/fpsdk_common/test/parser_nmea_test.cpp
+++ b/fpsdk_common/test/parser_nmea_test.cpp
@@ -12,6 +12,7 @@
  */
 
 /* LIBC/STL */
+#include <cstring>
 #include <string>
 
 /* EXTERNAL */
@@ -35,7 +36,7 @@ TEST(ParserNmeaTest, NmeaGetMessageMeta)
         //                  TTFFF PPPPPPPPPPP
         const char* msg = "$GNGGA,123,456,789*xx\r\n";
         NmeaMessageMeta meta;
-        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.talker_), std::string("GN")) << msg;
         EXPECT_EQ(std::string(meta.formatter_), std::string("GGA")) << msg;
         EXPECT_EQ(meta.payload_ix0_, 7) << msg;
@@ -48,7 +49,7 @@ TEST(ParserNmeaTest, NmeaGetMessageMeta)
         //                  TFFF PPPPPPPPPPPPPP
         const char* msg = "$PUBX,nn,123,456,789*xx\r\n";
         NmeaMessageMeta meta;
-        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.talker_), std::string("P")) << msg;
         EXPECT_EQ(std::string(meta.formatter_), std::string("UBX")) << msg;
         EXPECT_EQ(meta.payload_ix0_, 6) << msg;
@@ -61,7 +62,7 @@ TEST(ParserNmeaTest, NmeaGetMessageMeta)
         //                  TT,PPPPPPPPPPPPPPPPPPPPPP
         const char* msg = "$FP,ODOMETRY,n,...,...,...*xx\r\n";
         NmeaMessageMeta meta;
-        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.talker_), std::string("FP")) << msg;
         EXPECT_EQ(std::string(meta.formatter_), std::string("")) << msg;
         EXPECT_EQ(meta.payload_ix0_, 4) << msg;
@@ -74,7 +75,7 @@ TEST(ParserNmeaTest, NmeaGetMessageMeta)
         //                  TFFFF
         const char* msg = "$GPGGA*xx\r\n";
         NmeaMessageMeta meta;
-        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.talker_), std::string("GP")) << msg;
         EXPECT_EQ(std::string(meta.formatter_), std::string("GGA")) << msg;
         EXPECT_EQ(meta.payload_ix0_, 0) << msg;
@@ -93,12 +94,12 @@ TEST(ParserNmeaTest, NmeaGetMessageMeta)
     {
         const char* msg = "$ABCDEFGHIJKLMNOP";
         NmeaMessageMeta meta;
-        EXPECT_FALSE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg)));
+        EXPECT_FALSE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg)));
     }
     {
         const char* msg = "$GNABCDEFGHIJKLMNOPQRSTUVW,123,456,789*xx\r\n";
         NmeaMessageMeta meta;
-        EXPECT_FALSE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_FALSE(NmeaGetMessageMeta(meta, (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(meta.talker_), std::string("GN")) << msg;
         EXPECT_EQ(std::string(meta.formatter_), std::string("")) << msg;
         EXPECT_EQ(meta.payload_ix0_, 0) << msg;
@@ -114,7 +115,7 @@ TEST(ParserNmeaTest, NmeaGetMessageName)
     {
         const char* msg = "$GNGGA,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-GN-GGA")) << msg;
     }
 
@@ -122,74 +123,74 @@ TEST(ParserNmeaTest, NmeaGetMessageName)
     {
         const char* msg = "$PUBX,41,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-CONFIG")) << msg;
     }
     {
         const char* msg = "$PUBX,00,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-POSITION")) << msg;
     }
     {
         const char* msg = "$PUBX,40,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-RATE")) << msg;
     }
     {
         const char* msg = "$PUBX,03,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-SVSTATUS")) << msg;
     }
     {
         const char* msg = "$PUBX,04,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-TIME")) << msg;
     }
     {
         const char* msg = "$PUBX,99,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-99")) << msg;
     }
     {
         const char* msg = "$PUBX,42,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-42")) << msg;
     }
     {
         const char* msg = "$PUBX,01,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-PUBX-01")) << msg;
     }
     // Bad u-blox proprietary
     {
         const char* msg = "$PUBXX,00,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-P-UBXX")) << msg;
     }
     {
         const char* msg = "$PVBX,00,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-P-VBX")) << msg;
     }
     {
         const char* msg = "$PUCX,00,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-P-UCX")) << msg;
     }
     {
         const char* msg = "$PUBY,00,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-P-UBY")) << msg;
     }
 
@@ -197,7 +198,7 @@ TEST(ParserNmeaTest, NmeaGetMessageName)
     {
         const char* msg = "$PABC,123,456,789*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-P-ABC")) << msg;
     }
 
@@ -205,27 +206,27 @@ TEST(ParserNmeaTest, NmeaGetMessageName)
     {
         const char* msg = "$FP,ODOMETRY,n,...,...,...*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-FP-?")) << msg;
-        // EXPECT_FALSE(NmeaGetMessageName(name, 10, (const uint8_t*)msg, strlen(msg))) << msg;
+        // EXPECT_FALSE(NmeaGetMessageName(name, 10, (const uint8_t*)msg, std::strlen(msg))) << msg;
     }
     // Bad FP_A
     {
         const char* msg = "$GP,ODOMETRY,n,...,...,...*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-GP-?")) << msg;
     }
     {
         const char* msg = "$FQ,ODOMETRY,n,...,...,...*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-FQ-?")) << msg;
     }
     {
         const char* msg = "$FPP,ODOMETRY,n,...,...,...*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-FP-P")) << msg;
     }
 
@@ -233,7 +234,7 @@ TEST(ParserNmeaTest, NmeaGetMessageName)
     {
         const char* msg = "$GPGGA*xx\r\n";
         char name[100];
-        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_TRUE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-GP-GGA")) << msg;
     }
 
@@ -257,7 +258,7 @@ TEST(ParserNmeaTest, NmeaGetMessageName)
     {
         const char* msg = "$GPGGA*xx\r\n";
         char name[10];
-        EXPECT_FALSE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, strlen(msg))) << msg;
+        EXPECT_FALSE(NmeaGetMessageName(name, sizeof(name), (const uint8_t*)msg, std::strlen(msg))) << msg;
         EXPECT_EQ(std::string(name), std::string("NMEA-GP-G")) << msg;
     }
 }
@@ -309,23 +310,26 @@ TEST(ParserNmeaTest, NmeaGgaPayload)
     {
         NmeaGgaPayload gga;
         const char* not_a_gga = "$GNGLL,4724.018931,N,00827.023090,E,110546.800,A,D*4F\r\n";
-        EXPECT_FALSE(gga.SetFromMsg((const uint8_t*)not_a_gga, strlen(not_a_gga)));
+        EXPECT_FALSE(gga.SetFromMsg((const uint8_t*)not_a_gga, std::strlen(not_a_gga)));
         EXPECT_FALSE(gga.valid_);
-        EXPECT_EQ(gga.talker, NmeaTalkerId::UNSPECIFIED);  // we should not even get the talker
+        EXPECT_EQ(gga.talker_, NmeaTalkerId::UNSPECIFIED);  // we should not even get the talker
+        EXPECT_EQ(gga.formatter_, NmeaFormatter::GGA);
     }
     {
         NmeaGgaPayload gga;
         const char* bad_gga = "$GNGGA,092207.400,4724.017956,N,00827.022383*2E\r\n";
-        EXPECT_FALSE(gga.SetFromMsg((const uint8_t*)bad_gga, strlen(bad_gga)));
+        EXPECT_FALSE(gga.SetFromMsg((const uint8_t*)bad_gga, std::strlen(bad_gga)));
         EXPECT_FALSE(gga.valid_);
-        EXPECT_EQ(gga.talker, NmeaTalkerId::GNSS);  // we should still get the talker
+        EXPECT_EQ(gga.talker_, NmeaTalkerId::GNSS);  // we should still get the talker
+        EXPECT_EQ(gga.formatter_, NmeaFormatter::GGA);
     }
     {
         NmeaGgaPayload gga;
         const char* good_gga = "$GNGGA,092207.400,4724.017956,N,00827.022383,E,2,41,0.43,411.542,M,47.989,M,,*79\r\n";
-        EXPECT_TRUE(gga.SetFromMsg((const uint8_t*)good_gga, strlen(good_gga)));
+        EXPECT_TRUE(gga.SetFromMsg((const uint8_t*)good_gga, std::strlen(good_gga)));
         EXPECT_TRUE(gga.valid_);
-        EXPECT_EQ(gga.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gga.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gga.formatter_, NmeaFormatter::GGA);
         EXPECT_TRUE(gga.time.valid);
         EXPECT_EQ(gga.time.hours, 9);
         EXPECT_EQ(gga.time.mins, 22);
@@ -335,6 +339,8 @@ TEST(ParserNmeaTest, NmeaGgaPayload)
         EXPECT_NEAR(gga.llh.lat, 47.0 + (24.017956 / 60.0), 1e-12);
         EXPECT_NEAR(gga.llh.lon, 8.0 + (27.022383 / 60.0), 1e-12);
         EXPECT_NEAR(gga.llh.height, 411.542 + 47.989, 1e-9);
+        EXPECT_TRUE(gga.height_msl.valid);
+        EXPECT_NEAR(gga.height_msl.value, 411.542, 1e-9);
         EXPECT_EQ(gga.quality, NmeaQualityGga::DGNSS);
         EXPECT_TRUE(gga.num_sv.valid);
         EXPECT_EQ(gga.num_sv.value, 41);
@@ -349,9 +355,10 @@ TEST(ParserNmeaTest, NmeaGgaPayload)
         NmeaGgaPayload gga;
         const char* rtk_gga =
             "$GNGGA,104022.800,4724.017906,N,00827.021943,E,4,43,0.46,411.424,M,47.990,M,0.8,0000*50\r\n";
-        EXPECT_TRUE(gga.SetFromMsg((const uint8_t*)rtk_gga, strlen(rtk_gga)));
+        EXPECT_TRUE(gga.SetFromMsg((const uint8_t*)rtk_gga, std::strlen(rtk_gga)));
         EXPECT_TRUE(gga.valid_);
-        EXPECT_EQ(gga.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gga.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gga.formatter_, NmeaFormatter::GGA);
         EXPECT_TRUE(gga.time.valid);
         EXPECT_EQ(gga.time.hours, 10);
         EXPECT_EQ(gga.time.mins, 40);
@@ -361,6 +368,8 @@ TEST(ParserNmeaTest, NmeaGgaPayload)
         EXPECT_NEAR(gga.llh.lat, 47.0 + (24.017906 / 60.0), 1e-12);
         EXPECT_NEAR(gga.llh.lon, 8.0 + (27.021943 / 60.0), 1e-12);
         EXPECT_NEAR(gga.llh.height, 411.424 + 47.990, 1e-9);
+        EXPECT_TRUE(gga.height_msl.valid);
+        EXPECT_NEAR(gga.height_msl.value, 411.424, 1e-9);
         EXPECT_EQ(gga.quality, NmeaQualityGga::RTK_FIXED);
         EXPECT_TRUE(gga.num_sv.valid);
         EXPECT_EQ(gga.num_sv.value, 43);
@@ -374,9 +383,10 @@ TEST(ParserNmeaTest, NmeaGgaPayload)
     {
         NmeaGgaPayload gga;
         const char* good_gga = "$GNGGA,235943.812,,,,,0,00,99.99,,M,,M,,*49\r\n";
-        EXPECT_TRUE(gga.SetFromMsg((const uint8_t*)good_gga, strlen(good_gga)));
+        EXPECT_TRUE(gga.SetFromMsg((const uint8_t*)good_gga, std::strlen(good_gga)));
         EXPECT_TRUE(gga.valid_);
-        EXPECT_EQ(gga.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gga.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gga.formatter_, NmeaFormatter::GGA);
         EXPECT_TRUE(gga.time.valid);
         EXPECT_EQ(gga.time.hours, 23);
         EXPECT_EQ(gga.time.mins, 59);
@@ -386,6 +396,8 @@ TEST(ParserNmeaTest, NmeaGgaPayload)
         EXPECT_EQ(gga.llh.lon, 0.0);
         EXPECT_FALSE(gga.llh.height_valid);
         EXPECT_EQ(gga.llh.height, 0.0);
+        EXPECT_FALSE(gga.height_msl.valid);
+        EXPECT_EQ(gga.height_msl.value, 0.0);
         EXPECT_EQ(gga.quality, NmeaQualityGga::NOFIX);
         EXPECT_TRUE(gga.num_sv.valid);
         EXPECT_EQ(gga.num_sv.value, 0);
@@ -405,9 +417,10 @@ TEST(ParserNmeaTest, NmeaGllPayload)
     {
         NmeaGllPayload gll;
         const char* good_gll = "$GNGLL,4724.018931,N,00827.023090,E,110546.800,A,D*4F\r\n";
-        EXPECT_TRUE(gll.SetFromMsg((const uint8_t*)good_gll, strlen(good_gll)));
+        EXPECT_TRUE(gll.SetFromMsg((const uint8_t*)good_gll, std::strlen(good_gll)));
         EXPECT_TRUE(gll.valid_);
-        EXPECT_EQ(gll.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gll.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gll.formatter_, NmeaFormatter::GLL);
         EXPECT_TRUE(gll.time.valid);
         EXPECT_EQ(gll.time.hours, 11);
         EXPECT_EQ(gll.time.mins, 5);
@@ -423,9 +436,10 @@ TEST(ParserNmeaTest, NmeaGllPayload)
     {
         NmeaGllPayload gll;
         const char* gll_coldstart = "$GNGLL,,,,,235943.612,V,N*6B\r\n";
-        EXPECT_TRUE(gll.SetFromMsg((const uint8_t*)gll_coldstart, strlen(gll_coldstart)));
+        EXPECT_TRUE(gll.SetFromMsg((const uint8_t*)gll_coldstart, std::strlen(gll_coldstart)));
         EXPECT_TRUE(gll.valid_);
-        EXPECT_EQ(gll.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gll.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gll.formatter_, NmeaFormatter::GLL);
         EXPECT_TRUE(gll.time.valid);
         EXPECT_EQ(gll.time.hours, 23);
         EXPECT_EQ(gll.time.mins, 59);
@@ -447,19 +461,20 @@ TEST(ParserNmeaTest, NmeaRmcPayload)
     {
         NmeaRmcPayload rmc;
         const char* good_rmc = "$GNRMC,110546.800,A,4724.018931,N,00827.023090,E,0.015,139.17,231024,,,D,V*3D\r\n";
-        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)good_rmc, strlen(good_rmc)));
+        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)good_rmc, std::strlen(good_rmc)));
         EXPECT_TRUE(rmc.valid_);
-        EXPECT_EQ(rmc.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(rmc.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(rmc.formatter_, NmeaFormatter::RMC);
         EXPECT_TRUE(rmc.time.valid);
         EXPECT_EQ(rmc.time.hours, 11);
         EXPECT_EQ(rmc.time.mins, 5);
         EXPECT_NEAR(rmc.time.secs, 46.8, 1e-9);
         EXPECT_EQ(rmc.status, NmeaStatusGllRmc::VALID);
-        EXPECT_TRUE(rmc.llh.latlon_valid);
-        EXPECT_NEAR(rmc.llh.lat, 47.0 + (24.018931 / 60.0), 1e-12);
-        EXPECT_NEAR(rmc.llh.lon, 8.0 + (27.023090 / 60.0), 1e-12);
-        EXPECT_FALSE(rmc.llh.height_valid);  // no height in RMC
-        EXPECT_NEAR(rmc.llh.height, 0.0, 1e-9);
+        EXPECT_TRUE(rmc.ll.latlon_valid);
+        EXPECT_NEAR(rmc.ll.lat, 47.0 + (24.018931 / 60.0), 1e-12);
+        EXPECT_NEAR(rmc.ll.lon, 8.0 + (27.023090 / 60.0), 1e-12);
+        EXPECT_FALSE(rmc.ll.height_valid);  // no height in RMC
+        EXPECT_NEAR(rmc.ll.height, 0.0, 1e-9);
         EXPECT_TRUE(rmc.speed.valid);
         EXPECT_NEAR(rmc.speed.value, 0.015, 1e-6);
         EXPECT_TRUE(rmc.course.valid);
@@ -474,19 +489,20 @@ TEST(ParserNmeaTest, NmeaRmcPayload)
     {
         NmeaRmcPayload rmc;
         const char* rmc_coldstart = "$GNRMC,235943.412,V,,,,,,,050180,,,N,V*28\r\n";
-        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)rmc_coldstart, strlen(rmc_coldstart)));
+        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)rmc_coldstart, std::strlen(rmc_coldstart)));
         EXPECT_TRUE(rmc.valid_);
-        EXPECT_EQ(rmc.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(rmc.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(rmc.formatter_, NmeaFormatter::RMC);
         EXPECT_TRUE(rmc.time.valid);
         EXPECT_EQ(rmc.time.hours, 23);
         EXPECT_EQ(rmc.time.mins, 59);
         EXPECT_NEAR(rmc.time.secs, 43.412, 1e-9);
         EXPECT_EQ(rmc.status, NmeaStatusGllRmc::INVALID);
-        EXPECT_FALSE(rmc.llh.latlon_valid);
-        EXPECT_EQ(rmc.llh.lat, 0.0);
-        EXPECT_EQ(rmc.llh.lon, 0.0);
-        EXPECT_FALSE(rmc.llh.height_valid);
-        EXPECT_EQ(rmc.llh.height, 0.0);
+        EXPECT_FALSE(rmc.ll.latlon_valid);
+        EXPECT_EQ(rmc.ll.lat, 0.0);
+        EXPECT_EQ(rmc.ll.lon, 0.0);
+        EXPECT_FALSE(rmc.ll.height_valid);
+        EXPECT_EQ(rmc.ll.height, 0.0);
         EXPECT_FALSE(rmc.speed.valid);
         EXPECT_EQ(rmc.speed.value, 0.0);
         EXPECT_FALSE(rmc.course.valid);
@@ -501,19 +517,20 @@ TEST(ParserNmeaTest, NmeaRmcPayload)
     {
         NmeaRmcPayload rmc;
         const char* old_rmc = "$GPRMC,094821.1999,A,4724.0179049,N,00827.0219431,E,0.00151,250.7782,080125,,,R*73\r\n";
-        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)old_rmc, strlen(old_rmc)));
+        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)old_rmc, std::strlen(old_rmc)));
         EXPECT_TRUE(rmc.valid_);
-        EXPECT_EQ(rmc.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(rmc.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(rmc.formatter_, NmeaFormatter::RMC);
         EXPECT_TRUE(rmc.time.valid);
         EXPECT_EQ(rmc.time.hours, 9);
         EXPECT_EQ(rmc.time.mins, 48);
         EXPECT_NEAR(rmc.time.secs, 21.1999, 1e-9);
         EXPECT_EQ(rmc.status, NmeaStatusGllRmc::VALID);
-        EXPECT_TRUE(rmc.llh.latlon_valid);
-        EXPECT_NEAR(rmc.llh.lat, 47.0 + (24.017904 / 60.0), 1e-7);
-        EXPECT_NEAR(rmc.llh.lon, 8.0 + (27.021943 / 60.0), 1e-7);
-        EXPECT_FALSE(rmc.llh.height_valid);  // no height in RMC
-        EXPECT_NEAR(rmc.llh.height, 0.0, 1e-9);
+        EXPECT_TRUE(rmc.ll.latlon_valid);
+        EXPECT_NEAR(rmc.ll.lat, 47.0 + (24.017904 / 60.0), 1e-7);
+        EXPECT_NEAR(rmc.ll.lon, 8.0 + (27.021943 / 60.0), 1e-7);
+        EXPECT_FALSE(rmc.ll.height_valid);  // no height in RMC
+        EXPECT_NEAR(rmc.ll.height, 0.0, 1e-9);
         EXPECT_TRUE(rmc.speed.valid);
         EXPECT_NEAR(rmc.speed.value, 0.00151, 1e-6);
         EXPECT_TRUE(rmc.course.valid);
@@ -529,19 +546,20 @@ TEST(ParserNmeaTest, NmeaRmcPayload)
         NmeaRmcPayload rmc;
         const char* south_west_rmc =
             "$GNRMC,110546.800,A,4724.018931,S,00827.023090,W,0.015,139.17,231024,,,D,V*3D\r\n";
-        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)south_west_rmc, strlen(south_west_rmc)));
+        EXPECT_TRUE(rmc.SetFromMsg((const uint8_t*)south_west_rmc, std::strlen(south_west_rmc)));
         EXPECT_TRUE(rmc.valid_);
-        EXPECT_EQ(rmc.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(rmc.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(rmc.formatter_, NmeaFormatter::RMC);
         EXPECT_TRUE(rmc.time.valid);
         EXPECT_EQ(rmc.time.hours, 11);
         EXPECT_EQ(rmc.time.mins, 5);
         EXPECT_NEAR(rmc.time.secs, 46.8, 1e-9);
         EXPECT_EQ(rmc.status, NmeaStatusGllRmc::VALID);
-        EXPECT_TRUE(rmc.llh.latlon_valid);
-        EXPECT_NEAR(rmc.llh.lat, -(47.0 + (24.018931 / 60.0)), 1e-9);
-        EXPECT_NEAR(rmc.llh.lon, -(8.0 + (27.023090 / 60.0)), 1e-9);
-        EXPECT_FALSE(rmc.llh.height_valid);  // no height in RMC
-        EXPECT_NEAR(rmc.llh.height, 0.0, 1e-9);
+        EXPECT_TRUE(rmc.ll.latlon_valid);
+        EXPECT_NEAR(rmc.ll.lat, -(47.0 + (24.018931 / 60.0)), 1e-9);
+        EXPECT_NEAR(rmc.ll.lon, -(8.0 + (27.023090 / 60.0)), 1e-9);
+        EXPECT_FALSE(rmc.ll.height_valid);  // no height in RMC
+        EXPECT_NEAR(rmc.ll.height, 0.0, 1e-9);
         EXPECT_TRUE(rmc.speed.valid);
         EXPECT_NEAR(rmc.speed.value, 0.015, 1e-6);
         EXPECT_TRUE(rmc.course.valid);
@@ -562,9 +580,10 @@ TEST(ParserNmeaTest, NmeaVtgPayload)
     {
         NmeaVtgPayload vtg;
         const char* good_vtg = "$GNVTG,139.17,T,,M,0.015,N,0.027,K,D*2A\r\n";
-        EXPECT_TRUE(vtg.SetFromMsg((const uint8_t*)good_vtg, strlen(good_vtg)));
+        EXPECT_TRUE(vtg.SetFromMsg((const uint8_t*)good_vtg, std::strlen(good_vtg)));
         EXPECT_TRUE(vtg.valid_);
-        EXPECT_EQ(vtg.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(vtg.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(vtg.formatter_, NmeaFormatter::VTG);
         EXPECT_TRUE(vtg.cogt.valid);
         EXPECT_NEAR(vtg.cogt.value, 139.17, 1e-4);
         EXPECT_FALSE(vtg.cogm.valid);
@@ -577,9 +596,10 @@ TEST(ParserNmeaTest, NmeaVtgPayload)
     {
         NmeaVtgPayload vtg;
         const char* vtg_coldstart = "$GNVTG,,T,,M,,N,,K,N*32\r\n";
-        EXPECT_TRUE(vtg.SetFromMsg((const uint8_t*)vtg_coldstart, strlen(vtg_coldstart)));
+        EXPECT_TRUE(vtg.SetFromMsg((const uint8_t*)vtg_coldstart, std::strlen(vtg_coldstart)));
         EXPECT_TRUE(vtg.valid_);
-        EXPECT_EQ(vtg.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(vtg.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(vtg.formatter_, NmeaFormatter::VTG);
         EXPECT_FALSE(vtg.cogt.valid);
         EXPECT_EQ(vtg.cogt.value, 0.0);
         EXPECT_FALSE(vtg.cogm.valid);
@@ -598,9 +618,10 @@ TEST(ParserNmeaTest, NmeaGstPayload)
     {
         NmeaGstPayload gst;
         const char* good_gst = "$GPGST,132419.0000,,0.0515,0.0188,162.6609,0.0495,0.0236,0.0182*7D\r\n";
-        EXPECT_TRUE(gst.SetFromMsg((const uint8_t*)good_gst, strlen(good_gst)));
+        EXPECT_TRUE(gst.SetFromMsg((const uint8_t*)good_gst, std::strlen(good_gst)));
         EXPECT_TRUE(gst.valid_);
-        EXPECT_EQ(gst.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gst.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gst.formatter_, NmeaFormatter::GST);
         EXPECT_TRUE(gst.time.valid);
         EXPECT_EQ(gst.time.hours, 13);
         EXPECT_EQ(gst.time.mins, 24);
@@ -623,9 +644,10 @@ TEST(ParserNmeaTest, NmeaGstPayload)
     {
         NmeaGstPayload gst;
         const char* empty_gst = "$GPGST,,,,,,,,*XX\r\n";
-        EXPECT_TRUE(gst.SetFromMsg((const uint8_t*)empty_gst, strlen(empty_gst)));
+        EXPECT_TRUE(gst.SetFromMsg((const uint8_t*)empty_gst, std::strlen(empty_gst)));
         EXPECT_TRUE(gst.valid_);
-        EXPECT_EQ(gst.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gst.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gst.formatter_, NmeaFormatter::GST);
         EXPECT_FALSE(gst.time.valid);
         EXPECT_EQ(gst.time.hours, 0);
         EXPECT_EQ(gst.time.mins, 0);
@@ -654,18 +676,20 @@ TEST(ParserNmeaTest, NmeaHdtPayload)
     {
         NmeaHdtPayload hdt;
         const char* good_hdt = "$GPHDT,61.7183,T*3F\r\n";
-        EXPECT_TRUE(hdt.SetFromMsg((const uint8_t*)good_hdt, strlen(good_hdt)));
+        EXPECT_TRUE(hdt.SetFromMsg((const uint8_t*)good_hdt, std::strlen(good_hdt)));
         EXPECT_TRUE(hdt.valid_);
-        EXPECT_EQ(hdt.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(hdt.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(hdt.formatter_, NmeaFormatter::HDT);
         EXPECT_TRUE(hdt.heading.valid);
         EXPECT_NEAR(hdt.heading.value, 61.7183, 1e-9);
     }
     {
         NmeaHdtPayload hdt;
         const char* empty_hdt = "$GPHDT,,*3F\r\n";
-        EXPECT_TRUE(hdt.SetFromMsg((const uint8_t*)empty_hdt, strlen(empty_hdt)));
+        EXPECT_TRUE(hdt.SetFromMsg((const uint8_t*)empty_hdt, std::strlen(empty_hdt)));
         EXPECT_TRUE(hdt.valid_);
-        EXPECT_EQ(hdt.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(hdt.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(hdt.formatter_, NmeaFormatter::HDT);
         EXPECT_FALSE(hdt.heading.valid);
         EXPECT_EQ(hdt.heading.value, 0.0);
     }
@@ -678,9 +702,10 @@ TEST(ParserNmeaTest, NmeaZdaPayload)
     {
         NmeaZdaPayload zda;
         const char* good_zda = "$GPZDA,090411.0001,10,10,2023,00,00*69\r\n";
-        EXPECT_TRUE(zda.SetFromMsg((const uint8_t*)good_zda, strlen(good_zda)));
+        EXPECT_TRUE(zda.SetFromMsg((const uint8_t*)good_zda, std::strlen(good_zda)));
         EXPECT_TRUE(zda.valid_);
-        EXPECT_EQ(zda.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(zda.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(zda.formatter_, NmeaFormatter::ZDA);
         EXPECT_TRUE(zda.time.valid);
         EXPECT_EQ(zda.time.hours, 9);
         EXPECT_EQ(zda.time.mins, 4);
@@ -697,9 +722,10 @@ TEST(ParserNmeaTest, NmeaZdaPayload)
     {
         NmeaZdaPayload zda;
         const char* empty_zda = "$GPZDA,,,,,,*XX\r\n";
-        EXPECT_TRUE(zda.SetFromMsg((const uint8_t*)empty_zda, strlen(empty_zda)));
+        EXPECT_TRUE(zda.SetFromMsg((const uint8_t*)empty_zda, std::strlen(empty_zda)));
         EXPECT_TRUE(zda.valid_);
-        EXPECT_EQ(zda.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(zda.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(zda.formatter_, NmeaFormatter::ZDA);
         EXPECT_FALSE(zda.time.valid);
         EXPECT_EQ(zda.time.hours, 0);
         EXPECT_EQ(zda.time.mins, 0);
@@ -722,9 +748,10 @@ TEST(ParserNmeaTest, NmeaGsaPayload)
     {
         NmeaGsaPayload gsa;
         const char* good_gsa = "$GNGSA,A,3,03,04,06,07,09,11,19,20,26,30,31,,0.79,0.46,0.64,1*0F\r\n";
-        EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)good_gsa, strlen(good_gsa)));
+        EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)good_gsa, std::strlen(good_gsa)));
         EXPECT_TRUE(gsa.valid_);
-        EXPECT_EQ(gsa.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gsa.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gsa.formatter_, NmeaFormatter::GSA);
         EXPECT_EQ(gsa.opmode, NmeaOpModeGsa::AUTO);
         EXPECT_EQ(gsa.navmode, NmeaNavModeGsa::FIX3D);
         EXPECT_EQ(gsa.num_sats, 11);
@@ -775,9 +802,10 @@ TEST(ParserNmeaTest, NmeaGsaPayload)
     {
         NmeaGsaPayload gsa;
         const char* gsa_coldstart = "$GNGSA,A,1,,,,,,,,,,,,,99.99,99.99,99.99,5*37\r\n";
-        EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)gsa_coldstart, strlen(gsa_coldstart)));
+        EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)gsa_coldstart, std::strlen(gsa_coldstart)));
         EXPECT_TRUE(gsa.valid_);
-        EXPECT_EQ(gsa.talker, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gsa.talker_, NmeaTalkerId::GNSS);
+        EXPECT_EQ(gsa.formatter_, NmeaFormatter::GSA);
         EXPECT_EQ(gsa.opmode, NmeaOpModeGsa::AUTO);
         EXPECT_EQ(gsa.navmode, NmeaNavModeGsa::NOFIX);
         EXPECT_EQ(gsa.num_sats, 0);
@@ -835,9 +863,10 @@ TEST(ParserNmeaTest, NmeaGsvPayload)
         NmeaGsvPayload gsv;
         const char* gsv_2_of_4 =  // clang-format off
             "$GPGSV,4,2,14,"  "09,84,270,52,"  "11,,,46,"  "16,03,080,,"  "17,03,218,35,"  "1*XX\r\n";  // clang-format on
-        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_2_of_4, strlen(gsv_2_of_4)));
+        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_2_of_4, std::strlen(gsv_2_of_4)));
         EXPECT_TRUE(gsv.valid_);
-        EXPECT_EQ(gsv.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gsv.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gsv.formatter_, NmeaFormatter::GSV);
         EXPECT_TRUE(gsv.num_msgs.valid);
         EXPECT_EQ(gsv.num_msgs.value, 4);
         EXPECT_TRUE(gsv.msg_num.valid);
@@ -892,9 +921,10 @@ TEST(ParserNmeaTest, NmeaGsvPayload)
     {
         NmeaGsvPayload gsv;  // clang-format off
         const char* gsv_4_of_4 = "$GPGSV,4,4,14,"  "31,08,034,46,"  "36,31,149,43,"  "1*62\r\n";  // clang-format on
-        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_4_of_4, strlen(gsv_4_of_4)));
+        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_4_of_4, std::strlen(gsv_4_of_4)));
         EXPECT_TRUE(gsv.valid_);
-        EXPECT_EQ(gsv.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gsv.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gsv.formatter_, NmeaFormatter::GSV);
         EXPECT_TRUE(gsv.num_msgs.valid);
         EXPECT_EQ(gsv.num_msgs.value, 4);
         EXPECT_TRUE(gsv.msg_num.valid);
@@ -947,9 +977,10 @@ TEST(ParserNmeaTest, NmeaGsvPayload)
     {
         NmeaGsvPayload gsv;
         const char* gsv_1_of_1_nosv = "$GAGSV,1,1,00,1*75\r\n";
-        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_1_of_1_nosv, strlen(gsv_1_of_1_nosv)));
+        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_1_of_1_nosv, std::strlen(gsv_1_of_1_nosv)));
         EXPECT_TRUE(gsv.valid_);
-        EXPECT_EQ(gsv.talker, NmeaTalkerId::GAL);
+        EXPECT_EQ(gsv.talker_, NmeaTalkerId::GAL);
+        EXPECT_EQ(gsv.formatter_, NmeaFormatter::GSV);
         EXPECT_TRUE(gsv.num_msgs.valid);
         EXPECT_EQ(gsv.num_msgs.value, 1);
         EXPECT_TRUE(gsv.msg_num.valid);
@@ -973,9 +1004,10 @@ TEST(ParserNmeaTest, NmeaGsvPayload)
     {
         NmeaGsvPayload gsv;
         const char* bad_gsv_too_many_sv = "$GLGSV,1,1,12,1*75\r\n";
-        EXPECT_FALSE(gsv.SetFromMsg((const uint8_t*)bad_gsv_too_many_sv, strlen(bad_gsv_too_many_sv)));
+        EXPECT_FALSE(gsv.SetFromMsg((const uint8_t*)bad_gsv_too_many_sv, std::strlen(bad_gsv_too_many_sv)));
         EXPECT_FALSE(gsv.valid_);
-        EXPECT_EQ(gsv.talker, NmeaTalkerId::GLO);
+        EXPECT_EQ(gsv.talker_, NmeaTalkerId::GLO);
+        EXPECT_EQ(gsv.formatter_, NmeaFormatter::GSV);
         EXPECT_TRUE(gsv.num_msgs.valid);
         EXPECT_EQ(gsv.num_msgs.value, 1);
         EXPECT_TRUE(gsv.msg_num.valid);
@@ -1004,9 +1036,10 @@ TEST(ParserNmeaTest, NmeaGsvPayload)
             "23,01,241,,"
             "41,02,101,,"
             "0*53..";  // no cnos -> no signal
-        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)no_cno, strlen(no_cno)));
+        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)no_cno, std::strlen(no_cno)));
         EXPECT_TRUE(gsv.valid_);
-        EXPECT_EQ(gsv.talker, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gsv.talker_, NmeaTalkerId::GPS_SBAS);
+        EXPECT_EQ(gsv.formatter_, NmeaFormatter::GSV);
         EXPECT_TRUE(gsv.num_msgs.valid);
         EXPECT_EQ(gsv.num_msgs.value, 1);
         EXPECT_TRUE(gsv.msg_num.valid);
@@ -1060,9 +1093,10 @@ TEST(ParserNmeaTest, NmeaGsvPayload)
         NmeaGsvPayload gsv;
         const char* gsv_2_of_3 =  // clang-format off
             "$GBGSV,3,2,09," "25,65,282,09," "26,06,081,14," "35,17,044,08," "40,14,034,08," "B*00\r\n";  // clang-format on
-        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_2_of_3, strlen(gsv_2_of_3)));
+        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_2_of_3, std::strlen(gsv_2_of_3)));
         EXPECT_TRUE(gsv.valid_);
-        EXPECT_EQ(gsv.talker, NmeaTalkerId::BDS);
+        EXPECT_EQ(gsv.talker_, NmeaTalkerId::BDS);
+        EXPECT_EQ(gsv.formatter_, NmeaFormatter::GSV);
         EXPECT_TRUE(gsv.num_msgs.valid);
         EXPECT_EQ(gsv.num_msgs.value, 3);
         EXPECT_TRUE(gsv.msg_num.valid);
@@ -1115,9 +1149,10 @@ TEST(ParserNmeaTest, NmeaGsvPayload)
     {
         NmeaGsvPayload gsv;  // clang-format off
         const char* gsv_3_of_3 = "$GBGSV,3,3,09," "41,43,264,13," "B*3C\r\n";  // clang-format on
-        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_3_of_3, strlen(gsv_3_of_3)));
+        EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_3_of_3, std::strlen(gsv_3_of_3)));
         EXPECT_TRUE(gsv.valid_);
-        EXPECT_EQ(gsv.talker, NmeaTalkerId::BDS);
+        EXPECT_EQ(gsv.talker_, NmeaTalkerId::BDS);
+        EXPECT_EQ(gsv.formatter_, NmeaFormatter::GSV);
         EXPECT_TRUE(gsv.num_msgs.valid);
         EXPECT_EQ(gsv.num_msgs.value, 3);
         EXPECT_TRUE(gsv.msg_num.valid);
@@ -1213,14 +1248,14 @@ TEST(ParserNmeaTest, NmeaCollectGsaGsv)
         for (auto& gsa_msg : gsa_msgs) {
             NmeaGsaPayload gsa;
             // fprintf(stderr, "GSA: %s", gsa_msg);
-            EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)gsa_msg, strlen(gsa_msg)));
+            EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)gsa_msg, std::strlen(gsa_msg)));
             EXPECT_TRUE(gsa.valid_);
             EXPECT_TRUE(coll.AddGsa(gsa));
         }
         for (auto& gsv_msg : gsv_msgs) {
             NmeaGsvPayload gsv;
             // fprintf(stderr, "GSV: %s", gsv_msg);
-            EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_msg, strlen(gsv_msg)));
+            EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_msg, std::strlen(gsv_msg)));
             EXPECT_TRUE(gsv.valid_);
             EXPECT_TRUE(coll.AddGsv(gsv));
         }
@@ -1261,13 +1296,13 @@ TEST(ParserNmeaTest, NmeaCollectGsaGsv)
         std::vector<NmeaGsvPayload> gsvs;
         for (auto& gsa_msg : gsa_msgs) {
             NmeaGsaPayload gsa;
-            EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)gsa_msg, strlen(gsa_msg)));
+            EXPECT_TRUE(gsa.SetFromMsg((const uint8_t*)gsa_msg, std::strlen(gsa_msg)));
             EXPECT_TRUE(gsa.valid_);
             gsas.push_back(gsa);
         }
         for (auto& gsv_msg : gsv_msgs) {
             NmeaGsvPayload gsv;
-            EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_msg, strlen(gsv_msg)));
+            EXPECT_TRUE(gsv.SetFromMsg((const uint8_t*)gsv_msg, std::strlen(gsv_msg)));
             EXPECT_TRUE(gsv.valid_);
             gsvs.push_back(gsv);
         }
@@ -1315,6 +1350,21 @@ TEST(ParserNmeaTest, NmeaMakeMessage)
 
     EXPECT_TRUE(NmeaMakeMessage(msg, "Bad$h!7^*\t\\"));
     EXPECT_EQ(BufToStr(msg), std::string("$Bad_h_7____*18\r\n"));
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+TEST(ParserNmeaTest, NmeaDecodeMessage)
+{
+    {
+        const char* msg = "$GNGGA,092207.400,4724.017956,N,00827.022383,E,2,41,0.43,411.542,M,47.989,M,,*79\r\n";
+        const NmeaPayloadPtr payload = NmeaDecodeMessage((const uint8_t*)msg, std::strlen(msg));
+        EXPECT_TRUE(payload);
+        EXPECT_EQ(payload->formatter_, NmeaFormatter::GGA);
+        const auto gga = dynamic_cast<const NmeaGgaPayload&>(*payload);
+
+        EXPECT_EQ(gga.num_sv.value, 41);
+    }
 }
 
 /* ****************************************************************************************************************** */

--- a/fpsdk_common/test/parser_test.cpp
+++ b/fpsdk_common/test/parser_test.cpp
@@ -125,11 +125,11 @@ class ParserTest : public ::testing::Test
         std::size_t size = 0;
         while (parser.Process(msg)) {
             EXPECT_EQ(std::string(msg.name_), std::string("OTHER"));
-            size += msg.data_.size();
+            size += msg.Size();
         }
         while (parser.Flush(msg)) {
             EXPECT_EQ(std::string(msg.name_), std::string("OTHER"));
-            size += msg.data_.size();
+            size += msg.Size();
         }
         EXPECT_EQ(size, data.size());
     }
@@ -177,7 +177,7 @@ TEST_F(ParserTest, Parser)
     EXPECT_FALSE(parser.Process(msg));
     EXPECT_TRUE(parser.Add(garbage1));
     EXPECT_TRUE(parser.Process(msg));
-    EXPECT_EQ(std::vector<uint8_t>(msg.data_.data(), msg.data_.data() + garbage2.size()), garbage2);
+    EXPECT_EQ(std::vector<uint8_t>(msg.Data(), msg.Data() + garbage2.size()), garbage2);
     EXPECT_EQ(
         std::vector<uint8_t>(&msg.data_[garbage2.size()], &msg.data_[garbage2.size()] + garbage1.size()), garbage1);
 
@@ -561,7 +561,7 @@ TEST_F(ParserTest, IncompleteMsg)
         EXPECT_TRUE(parser.Add(data, sizeof(data) - 1));
         EXPECT_FALSE(parser.Process(msg));
         EXPECT_TRUE(parser.Flush(msg));
-        EXPECT_EQ(msg.data_.size(), sizeof(data) - 1);
+        EXPECT_EQ(msg.Size(), sizeof(data) - 1);
     }
 }
 

--- a/fpsdk_common/test/parser_ubx_test.cpp
+++ b/fpsdk_common/test/parser_ubx_test.cpp
@@ -115,7 +115,7 @@ TEST(ParserUbxTest, UbxMakeMessage)
         parser.Add(msg);
         ParserMsg parser_message;
         EXPECT_TRUE(parser.Process(parser_message));
-        EXPECT_EQ(parser_message.data_.size(), UBX_FRAME_SIZE + payload.size());
+        EXPECT_EQ(parser_message.Size(), UBX_FRAME_SIZE + payload.size());
         EXPECT_EQ(std::string(parser_message.name_), std::string("UBX-AA-55"));
         // Payload should be the same
         EXPECT_TRUE(std::memcmp(payload.data(), &parser_message.data_[UBX_HEAD_SIZE], payload.size()) == 0);

--- a/fpsdk_doc/fpsdk_build.hpp
+++ b/fpsdk_doc/fpsdk_build.hpp
@@ -37,15 +37,15 @@ namespace fpsdk {
     For building the libraries and apps:
 
     - **Linux**, GCC (C++-17), glibc, cmake, bash, etc. (tested with Ubuntu 20.04/22.04/24.04 and Debian Trixie)
-    - boost            (≥ 1.71.0, tested with 1.71.0, 1.74.1, 1.83.0)
-    - curl             (≥ 7.68.0, tested with 7.68.0, 7.88.1, 8.5.0)
-    - Eigen3           (≥ 3.3.7,  tested with 3.3.7, 3.4.0)
-    - yaml-cpp         (≥ 0.6.2,  tested with 0.6.2, 0.7.0, 0.8.0)
-    - zlib1g           (≥ 1.2.11, tested with 1.2.11, 1.2.13, 1.3)
-    - OpenSSL (libssl) (≥ 1.1.x,  tested with 1.1.1, 3.0.2, 3.0.13, 3.0.15)
-    - nlohmann-json3   (≥ 3.7.3,  tested with 3.7.3, 3.11.3)
+    - boost            (≥ 1.71.0)
+    - curl             (≥ 7.68.0)
+    - Eigen3           (≥ 3.3.7)
+    - yaml-cpp         (≥ 0.6.2)
+    - zlib1g           (≥ 1.2.11)
+    - OpenSSL (libssl) (≥ 1.1.x)
+    - nlohmann-json3   (≥ 3.7.3)
     - Various Linux tools, including Bash, CMake, make, xxd, sed, awk, ...
-    - PROJ         (*) (≥ 9.4.x,  tested with 9.4.1, 9.6.0)
+    - PROJ         (*) (≥ 9.4.x)
     - ROS1         (*) (Noetic), or
     - ROS2         (*) (Humble or Jazzy)
 
@@ -54,8 +54,11 @@ namespace fpsdk {
     For development additionally:
 
     - clang-format (≥ 19, tested with 19)
-    - Doxygen      (≥ 1.11.0, tested with 1.11.0)
-    - GTest        (≥ 1.12.0, tested with 1.12.1 and 1.13.0)
+    - Doxygen      (≥ 1.11.0, tested with 1.14.0)
+    - GTest        (≥ 1.12.0)
+
+    Note that the list above may be incomplete or wrong. See @ref FPSDK_BUILD_CIVERSIONS for the versions used in the CI
+    builds.
 
     <!-- trick doxygen -->
 
@@ -228,7 +231,27 @@ namespace fpsdk {
     and the CI script (`docker/ci.sh`) for details on how things are done.
 
 
+    @section FPSDK_BUILD_CIVERSIONS Dependency versions
 
+
+    The builds using Debian 13 "Trixie" currently use:
+
+    @include fpsdk_common_versions_trixie/fpsdk_common/fpsdk_common_versions.txt
+
+
+    The builds using ROS Noetic (Ubuntu 20.04.6 LTS "Focal") currently use:
+
+    @include fpsdk_common_versions_noetic/fpsdk_common/fpsdk_common_versions.txt
+
+
+    The builds using ROS Humble (Ubuntu 22.04 LTS "Jammy") currently use:
+
+    @include fpsdk_common_versions_humble/fpsdk_common/fpsdk_common_versions.txt
+
+
+    The builds using ROS Jazzy (Ubuntu 24.04 LTS "Noble") currently use:
+
+    @include fpsdk_common_versions_jazzy/fpsdk_common/fpsdk_common_versions.txt
 */
 
 // clang-format on


### PR DESCRIPTION
- Cleanup and extend fpsdk::common::gnss stuff
  - Make (enum, code) order of GNSS and signals consistent everywhere
  - Add SigUse, SigCorr, SigIono, SigHealth and SatOrb enums along with conversion functions from UBX and NMEA
  - Replace Sat and SatSig with classes of the same name, put all conversion and helpers into those, add comparison and hash operates for them
  - Update signals list, GNSS,  add NavIC
- Cleanup FP_A and NMEA message structs
  - Remove unnecessary Doxygen duplications
  - Add {Fpa,Nmea}DecodeMessage() helpers
- Add ParserMsg::{Size,Data}() helpers
- Add some more UBX stringification, fixes, cosmetics
- Fix some docu
- Generate list of dependencies with versions, include that in doxygen