### PR TITLE
Fix clang compiler error

### DIFF
--- a/fpsdk_common/include/fpsdk_common/ext/eigen_core.hpp
+++ b/fpsdk_common/include/fpsdk_common/ext/eigen_core.hpp
@@ -7,11 +7,15 @@
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"  // NOLINT
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 #  pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #endif
 #pragma GCC diagnostic ignored "-Wclass-memaccess"  // NOLINT
+#endif
+
 #include <Eigen/Core>
 #pragma GCC diagnostic pop
 // For older Eigen (e.g. 3.3.7, which we have in fusion-dev-env and on the sensor), we unfortunately have to disable

--- a/fpsdk_common/include/fpsdk_common/ext/eigen_geometry.hpp
+++ b/fpsdk_common/include/fpsdk_common/ext/eigen_geometry.hpp
@@ -7,11 +7,15 @@
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wclass-memaccess"  // NOLINT
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 #  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #  pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #endif
+#endif
+
 #include <Eigen/Geometry>
 #pragma GCC diagnostic pop
 // See exmplanation in eigen_core.hpp


### PR DESCRIPTION
I failed to compile the `fpsdk_common` since I am compiling with clang. 

```
Ubuntu clang version 20.1.8 (++20250708082409+6fb913d3e2ec-1~exp1~20250708202428.132)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-20/bin
```

This is not a proper solution, but enough to unlock the building. I have seen that there is quite many warning bypasses for eigen in other headers, but this are not directly used by `fpsdk_common` which is a hard dependency to build the ros2 driver.
