### PR TITLE
make GetMillis() return > 0

### DIFF
--- a/fpsdk_common/include/fpsdk_common/time.hpp
+++ b/fpsdk_common/include/fpsdk_common/time.hpp
@@ -90,7 +90,7 @@ static constexpr uint64_t SecToNsec(const double sec)
  *
  * Time is monotonic time since first call to GetMillis() or GetSecs().
  *
- * @returns the number of milliseconds
+ * @returns the number of milliseconds (> 0)
  */
 uint64_t GetMillis();
 

--- a/fpsdk_common/src/time.cpp
+++ b/fpsdk_common/src/time.cpp
@@ -47,8 +47,8 @@ uint64_t GetMillis()
     static uint64_t t0 = 0;
     uint64_t t = (tp.tv_sec * 1000) + (tp.tv_nsec / 1000000);
     if (t0 == 0) {
-        t0 = t;
-        return 0;
+        t0 = t - 1;
+        return 1;
     }
     return t - t0;
 }


### PR DESCRIPTION
This fixes DEBUG_THR() et al. in the cases they make the first call to GetMillis().