### PR TITLE
Add argument to SetThreadName() for more control

### DIFF
--- a/fpsdk_common/include/fpsdk_common/thread.hpp
+++ b/fpsdk_common/include/fpsdk_common/thread.hpp
@@ -334,9 +334,10 @@ class Thread
  *
  * Sets the thread name, which shows in htop etc.
  *
- * @param[in]  name  The thread name (1-6 characters, longer \c name is clipped at 6 chars)
+ * @param[in]  name  The thread name (too long name is clipped )
+ * @param[in]  curr  How many characters of the original thread name to keep
  */
-void SetThreadName(const std::string& name);
+void SetThreadName(const std::string& name, const std::size_t curr = 6);
 
 /**
  * @brief Get numeric thread ID


### PR DESCRIPTION
- By default use 6 chars of the original thread name, i,e. keep the current behaviour
- Allow changing that, down to 0 for complete control of the thread name