### PR TITLE
fix Time::SetWnoTow() and Time::SetUtcTime() handling for negative values, add unittests

### DIFF
--- a/fpsdk.code-workspace
+++ b/fpsdk.code-workspace
@@ -326,6 +326,22 @@
                     { "text": "handle SIGPIPE nostop noprint pass", "description": "ignore SIGPIPE", "ignoreFailures": true },
                     { "text": "source ${workspaceFolder}/.devcontainer/.gdb/gdbinit", "description": "load local gdbinit", "ignoreFailures": false }
                 ]
+            },
+            {
+                "name": "Fixposition SDK: debug time_test",
+                "type": "cppdbg", "request": "launch", "MIMode": "gdb", "miDebuggerPath" : "gdb",
+                "stopAtEntry": false,
+                "preLaunchTask" : "Fixposition SDK: build",
+                "program": "${workspaceFolder}/build/Debug/fpsdk_common/fpsdk_common_time_test",
+                "args": [ // "--gtest_filter=TimeTest.SetUtcTime",
+                    "-v", "-v", "-v", "-v" ],
+                "cwd": "${workspaceFolder}",
+                "setupCommands": [
+                    { "text": "set auto-load safe-path ${workspaceFolder}", "description": "", "ignoreFailures": true },
+                    { "text": "-enable-pretty-printing", "description": "enable pretty printing", "ignoreFailures": true },
+                    { "text": "handle SIGPIPE nostop noprint pass", "description": "ignore SIGPIPE", "ignoreFailures": true },
+                    { "text": "source ${workspaceFolder}/.devcontainer/.gdb/gdbinit", "description": "load local gdbinit", "ignoreFailures": false }
+                ]
             }
         ],
         "compounds": []

--- a/fpsdk_common/include/fpsdk_common/time.hpp
+++ b/fpsdk_common/include/fpsdk_common/time.hpp
@@ -719,6 +719,8 @@ class Time
     /**
      * @brief From GNSS time (atomic)
      *
+     * See SetWnoTow() for details.
+     *
      * @param[in]  wnotow  GNSS time
      *
      * @returns the Time object

--- a/fpsdk_common/test/time_test.cpp
+++ b/fpsdk_common/test/time_test.cpp
@@ -1626,6 +1626,169 @@ TEST(TimeTest, SecNsec)
     EXPECT_NEAR(NsecToSec(n2), s2, 1e-9);
 }
 
+// ---------------------------------------------------------------------------------------------------------------------
+
+TEST(TimeTest, SetWnoTow)
+{
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, SEC_IN_WEEK_D }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 1001);
+        EXPECT_NEAR(wt.tow_, 0.0, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, SEC_IN_WEEK_D + 123.456789012 }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 1001);
+        EXPECT_NEAR(wt.tow_, 123.456789012, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, 2 * SEC_IN_WEEK_D }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 1002);
+        EXPECT_NEAR(wt.tow_, 0.0, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, -123.456789012 }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 999);
+        EXPECT_NEAR(wt.tow_, SEC_IN_WEEK_D - 123.456789012, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, -SEC_IN_WEEK_D }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 999);
+        EXPECT_NEAR(wt.tow_, 0.0, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, -2 * SEC_IN_WEEK_D }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 998);
+        EXPECT_NEAR(wt.tow_, 0.0, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, SEC_IN_WEEK_D - 1e-9 }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 1000);
+        EXPECT_NEAR(wt.tow_, SEC_IN_WEEK_D - 1e-9, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, SEC_IN_WEEK_D + 1e-9 }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 1001);
+        EXPECT_NEAR(wt.tow_, 1e-9, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetWnoTow({ 1000, -1e-9 }));
+        const auto wt = t.GetWnoTow();
+        EXPECT_EQ(wt.wno_, 999);
+        EXPECT_NEAR(wt.tow_, SEC_IN_WEEK_D - 1e-9, 1e-10);
+    }
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+TEST(TimeTest, SetUtcTime)
+{
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 15, 12, 30, -0.1 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 2);
+        EXPECT_EQ(utc.day_, 15);
+        EXPECT_EQ(utc.hour_, 12);
+        EXPECT_EQ(utc.min_, 29);
+        EXPECT_NEAR(utc.sec_, 59.9, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 15, 12, 0, -0.1 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 2);
+        EXPECT_EQ(utc.day_, 15);
+        EXPECT_EQ(utc.hour_, 11);
+        EXPECT_EQ(utc.min_, 59);
+        EXPECT_NEAR(utc.sec_, 59.9, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 15, 0, 0, -0.1 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 2);
+        EXPECT_EQ(utc.day_, 14);
+        EXPECT_EQ(utc.hour_, 23);
+        EXPECT_EQ(utc.min_, 59);
+        EXPECT_NEAR(utc.sec_, 59.9, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 1, 0, 0, -0.1 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 1);
+        EXPECT_EQ(utc.day_, 31);
+        EXPECT_EQ(utc.hour_, 23);
+        EXPECT_EQ(utc.min_, 59);
+        EXPECT_NEAR(utc.sec_, 59.9, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 15, 12, -1, 30.0 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 2);
+        EXPECT_EQ(utc.day_, 15);
+        EXPECT_EQ(utc.hour_, 11);
+        EXPECT_EQ(utc.min_, 59);
+        EXPECT_NEAR(utc.sec_, 30.0, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 15, -1, 30, 30.0 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 2);
+        EXPECT_EQ(utc.day_, 14);
+        EXPECT_EQ(utc.hour_, 23);
+        EXPECT_EQ(utc.min_, 30);
+        EXPECT_NEAR(utc.sec_, 30.0, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 1, -1, 30, 30.0 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 1);
+        EXPECT_EQ(utc.day_, 31);
+        EXPECT_EQ(utc.hour_, 23);
+        EXPECT_EQ(utc.min_, 30);
+        EXPECT_NEAR(utc.sec_, 30.0, 1e-10);
+    }
+    {
+        Time t;
+        EXPECT_TRUE(t.SetUtcTime({ 2000, 2, 15, 12, -1, -0.1 }));
+        const auto utc = t.GetUtcTime();
+        EXPECT_EQ(utc.year_, 2000);
+        EXPECT_EQ(utc.month_, 2);
+        EXPECT_EQ(utc.day_, 15);
+        EXPECT_EQ(utc.hour_, 11);
+        EXPECT_EQ(utc.min_, 58);
+        EXPECT_NEAR(utc.sec_, 59.9, 1e-10);
+    }
+}
+
 /* ****************************************************************************************************************** */
 }  // namespace
 


### PR DESCRIPTION
While negative WnoTow::tow_ or UtcTime::sec_ isn't really a valid time, it is handy to support handling these.
For example, when reading time info from GNSS receiver we may get a slightly negative UTC sec (for example UBX-NAV-PVT.sec = 0 and .nano < 0).
